### PR TITLE
Test2022 (#61)

### DIFF
--- a/src/components/AccountInfo.js
+++ b/src/components/AccountInfo.js
@@ -1,9 +1,8 @@
-import React from "react"
-import {connect} from "react-redux"
+import { connect } from "react-redux"
+import { ReactComponent as ClearIcon } from "../resources/clear.svg"
 import "../styles/accountInfo.css"
 import "../styles/buttons.css"
 import "../styles/postView.css"
-import {ReactComponent as ClearIcon} from "../resources/clear.svg"
 
 export const AccountInfo = (props) => {
     const changeInfo = (event) => {
@@ -28,7 +27,7 @@ export const AccountInfo = (props) => {
     }
 
     return(
-        <div className="userInformationContainer centerAlignWithPadding">
+        <div className="userInformationContainer centerAlignWithPaddingContainer">
             <div className="postTitleContainer">
               <h1 className="titleText centerAlignWithPadding">{props.user !== null && props.user.username !== "" ? props.user.username : props.settings.strings["profile"]}</h1>
               <ClearIcon className="clearIcon" onClick={closeClick}/>

--- a/src/components/ChangeUserName.js
+++ b/src/components/ChangeUserName.js
@@ -25,8 +25,8 @@ export const ChangeUserName = (props) => {
     props.history.push("/my-account/");
   };
   return (
-    <div className="loginContainer centerAlignWithPadding">
-      <h1 className="headerText bottomPadding30">
+    <div className="loginContainer centerAlignWithPaddingContainer">
+      <h1 className="headerText2 bottomPadding30">
         {props.settings.strings["set_username"]}
       </h1>
       <form className="loginForm" onSubmit={confirmUser}>

--- a/src/components/ContentArea.js
+++ b/src/components/ContentArea.js
@@ -1,32 +1,35 @@
 // By: Niklas Impiö
-import React from "react"
-import {connect} from "react-redux"
-import {Route, Link} from "react-router-dom"
+import { connect } from "react-redux"
+import { Link, Route } from "react-router-dom"
 
 import "../styles/containers.css"
 import "../styles/texts.css"
 
-import notificationReducer, {notify} from "../reducers/notificationReducer"
-import NewPostCombined from "./NewPostCombined"
-import NewMemento from "./NewMemento"
-import PostView from "./PostView"
-import ListView from "./ListView"
-import MyPosts from "./MyPosts"
-import LoginForm from "./LoginForm"
-import PopUpContainer from "./PopUpContainer"
+import CookieConsent from "react-cookie-consent"
+import { notify } from "../reducers/notificationReducer"
 import About from "./About"
-import ProjectInfo from "./ProjectInfo"
-import MapContainerOpen from "./MapContainerOpen"
-import UnverifiedPosts from "./UnverifiedPosts"
-import EditPost  from "./EditPost"
-import ImagelessPosts from "./ImagelessPosts"
-import UserSettings  from "./UserSettings"
-import ChangeUserName from "./ChangeUserName"
-import SetUserName from "./SetUserName"
 import AccountInfo from "./AccountInfo"
-import CookieConsent, { Cookies } from "react-cookie-consent";
+import ChangeUserName from "./ChangeUserName"
+import EditImage from "./EditImage"
+import EditLocation from "./EditLocation"
+import EditPost from "./EditPost"
+import EditSiteTitle from "./EditSiteTitle"
+import ImagelessPosts from "./ImagelessPosts"
+import ListView from "./ListView"
+import LoginForm from "./LoginForm"
+import MapContainerOpen from "./MapContainerOpen"
+import MyPosts from "./MyPosts"
+import NewMemento from "./NewMemento"
+import NewPostCombined from "./NewPostCombined"
+import PopUpContainer from "./PopUpContainer"
+import PostView from "./PostView"
+import ProjectInfo from "./ProjectInfo"
 import ProjectManagement from "./ProjectManagement"
+import ProjectModerators from "./ProjectModerators"
 import ProjectSettings from "./ProjectSettings"
+import SetUserName from "./SetUserName"
+import UnverifiedPosts from "./UnverifiedPosts"
+import UserSettings from "./UserSettings"
 
 const ContentArea = (props) => {
   // Ok this is just a container component for all the sub components that aren't NavBar or Notification.
@@ -66,6 +69,21 @@ const ContentArea = (props) => {
       <Route path="/edit-post/:id/" render={({match,history}) => (
         <PopUpContainer history={history}>
           <EditPost match={match} history={history}/>
+        </PopUpContainer>
+      )}/>
+      <Route path="/edit-image/:id/" render={({match,history}) => (
+        <PopUpContainer history={history}>
+          <EditImage match={match} history={history}/>
+        </PopUpContainer>
+      )}/>
+      <Route path="/edit-title/:id/" render={({match,history}) => (
+        <PopUpContainer history={history}>
+          <EditSiteTitle match={match} history={history}/>
+        </PopUpContainer>
+      )}/>
+      <Route path="/edit-location/:id/" render={({match,history}) => (
+        <PopUpContainer history={history}>
+          <EditLocation match={match} history={history}/>
         </PopUpContainer>
       )}/>
       <Route path="/new-memento/:id/" render={({match,history}) => (
@@ -126,6 +144,11 @@ const ContentArea = (props) => {
       <Route path="/project-settings" render={({history}) => (
         <PopUpContainer history={history}>
           <ProjectSettings history={history}/>
+        </PopUpContainer>
+      )}/>
+      <Route path="/project-moderators" render={({history}) => (
+        <PopUpContainer history={history}>
+          <ProjectModerators history={history}/>
         </PopUpContainer>
       )}/>
       <CookieConsent  //TODO: modelize, styles, add to mobile as well

--- a/src/components/DropDownList.js
+++ b/src/components/DropDownList.js
@@ -1,5 +1,4 @@
 // By: Niklas Impiö
-import React from "react"
 import "../styles/dropDownList.css"
 
 

--- a/src/components/DropDownSelect.js
+++ b/src/components/DropDownSelect.js
@@ -1,13 +1,12 @@
 // By: Niklas Impiö
-import React from "react"
-import {connect} from "react-redux"
+import { connect } from "react-redux"
 import useComponentVisible from "../hooks/OutsideClick"
 
-import DropDownList from "./DropDownList"
-import {ReactComponent as DropDownIcon} from "../resources/arrow_drop_down-24px.svg"
+import { ReactComponent as DropDownIcon } from "../resources/arrow_drop_down-24px.svg"
 import "../styles/dropDownSelect.css"
+import DropDownList from "./DropDownList"
 
-import {setActiveProject} from "../reducers/projectReducer"
+import { setActiveProject } from "../reducers/projectReducer"
 
 
 

--- a/src/components/DropDownSelectProject.js
+++ b/src/components/DropDownSelectProject.js
@@ -1,13 +1,12 @@
 // By: Niklas Impiö
-import React from "react"
-import {connect} from "react-redux"
+import { connect } from "react-redux"
 import useComponentVisible from "../hooks/OutsideClick"
 
-import DropDownList from "./DropDownList"
-import {ReactComponent as DropDownIcon} from "../resources/arrow_drop_down-24px.svg"
+import { ReactComponent as DropDownIcon } from "../resources/arrow_drop_down-24px.svg"
 import "../styles/dropDownSelect.css"
+import DropDownList from "./DropDownList"
 
-import {setActiveProject} from "../reducers/projectReducer"
+import { setActiveProject } from "../reducers/projectReducer"
 
 
 

--- a/src/components/EditImage.js
+++ b/src/components/EditImage.js
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
+
+import { changeSitePicture } from "../reducers/postReducer"
+import { setTempSite } from "../reducers/tempSiteReducer"
+import "../styles/buttons.css"
+import "../styles/newPost.css"
+import SiteImageUpload from "./SiteImageUpload"
+
+
+
+export const EditImage = (props) => {
+  const [image, setImage] = useState(null)
+  const post = props.posts.find(item => "" + item.id === props.match.params.id)
+  
+  useEffect(() => {      
+    if(props.tempSite.image){
+      setImage(props.tempSite.image.data
+        )}else{setImage(props.tempSite.image)}
+  }, [props])
+
+
+  const cancelClick = (event) => {
+    event.preventDefault()
+    setImage(null)
+    props.setTempSite({"title": "", "location":false, "image": null})
+    props.history.goBack()
+  }
+
+  const imageOnChangeHandler = (image) => {
+    setImage(image)
+  }
+
+  const confirmPost = (event) => {
+    event.preventDefault()  
+    props.changeSitePicture(post, image)
+    setImage(null)
+    props.setTempSite({"title": "", "location":false, "image": null})
+    props.history.goBack()
+  }
+
+
+  return(
+    <div className="newPostContainer centerAlignWithPaddingLean">
+    <h1 className="headerText">{props.settings.strings["change_image"]}</h1>
+	<div>
+      <form className="postForm" onSubmit={confirmPost}>
+        <div className="inputContainer">
+          <SiteImageUpload  change={imageOnChangeHandler}/>
+        </div>
+        <div className="postFormButtonContainer">
+          <button type="submit" className="rippleButton positiveButton fillButton">{props.settings.strings["submit"]}</button>
+          <button type="button" className="rippleButton negativeButton fillButton" onClick={cancelClick}>{props.settings.strings["cancel"]}</button>
+        </div>
+      </form>
+	</div>
+    </div>
+  )
+
+}
+
+const mapStateToProps = (state) => {
+  return {
+    //maps state to props, after this you can for example call props.notification
+    user: state.user,
+    tempSite: state.tempSite,
+    projects: state.projects,
+    settings: state.settings,
+    posts: state.posts
+  }
+}
+
+const mapDispatchToProps = {
+  //connect reducer functions/dispatchs to props
+  setTempSite,
+  changeSitePicture
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(EditImage)

--- a/src/components/EditLocation.js
+++ b/src/components/EditLocation.js
@@ -1,0 +1,115 @@
+import L from "leaflet"
+import { useState } from "react"
+import { MapContainer, Marker, TileLayer, useMapEvents } from "react-leaflet"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
+import { ChangeSiteLocation } from "../reducers/postReducer"
+
+import "leaflet/dist/leaflet.css"
+import tempIconMarker from "../resources/temp_marker.svg"
+import "../styles/buttons.css"
+import "../styles/mapContainer.css"
+import "../styles/newPost.css"
+
+const tempIcon = L.icon({
+  iconUrl: tempIconMarker,
+  iconAnchor: [16,32]
+})
+
+export const EditLocation = (props) => {
+  const post = props.posts.find(item => "" + item.id === props.match.params.id)
+  const [position, setPosition] = useState({lat: 65.01157565139543, lng: 25.470943450927738})
+  const [tempMarker, setTempMarker] = useState(null)
+  const [newLat, setNewLat] = useState(null)
+  const [newLng, setNewLng] = useState(null)
+
+  const ConfirmNewLocation = (event) => {
+    event.preventDefault()
+    //if input fields were empty
+    if(newLat === null || newLng === null)
+    {
+      props.notify(props.settings.strings["no_new_changes"], false, 5)
+    }
+    //if some new values were entered
+    else {
+      props.ChangeSiteLocation(post, newLat, newLng)
+    }
+    props.history.push(`/edit-post/${post.id}`)
+  }
+
+  //function for handling events on the map
+  const HandleMapEvents = () => {
+    useMapEvents({
+      click: (e) => {
+        if(props.user !== null) {
+          setNewLat(e.latlng.lat)
+          setNewLng(e.latlng.lng)
+          setPosition(e.latlng)
+          setTempMarker(e.latlng)
+        }
+      }
+    });
+    return null;
+  }
+
+  return(
+    <div className="userSettingsContainer centerAlignWithPadding">
+        <div className="titleContainer">
+          <h1 className="titleText">{props.settings.strings["choose_new_location"]}</h1>
+        </div>
+        <div className="mapContainerSmall">
+          <MapContainer className="smallMap" center={position} zoom={5}>
+          <TileLayer
+            attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+          <HandleMapEvents/>
+          {tempMarker !== null && props.currentProject.id !== "parantolat"?
+            <Marker position={tempMarker} icon={tempIcon}></Marker>
+            :
+            <></>
+          }
+          </MapContainer>
+        </div>
+        <div className="userInformation">
+          <table>
+            <tbody>
+              <tr className="userInfoRows">
+                <th className="userInfoValues">Latitude</th>
+                <th className="userInfoValues">{newLat !== null? newLat : "-"}</th>
+              </tr>
+              <tr className="userInfoRows">
+                <th className="userInfoValues">Longitude</th>
+                <th className="userInfoValues">{newLng !== null? newLng : "-"}</th>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div className="dualButtonContainer">
+          <button className="positiveButton rippleButton fillButton" onClick={ConfirmNewLocation}>{props.settings.strings["confirm"]}</button>
+          <button className="negativeButton rippleButton fillButton" onClick={() => props.history.push(`/edit-post/${post.id}`)}>{props.settings.strings["cancel"]}</button>
+        </div>
+      </div>
+  )
+
+}
+
+const mapStateToProps = (state) => {
+  return {
+    //maps state to props, after this you can for example call props.notification
+    settings: state.settings,
+    posts: state.posts,
+    currentProject: state.projects.active
+  }
+}
+
+const mapDispatchToProps = {
+  //connect reducer functions/dispatchs to props
+  notify,
+  ChangeSiteLocation
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(EditLocation)

--- a/src/components/EditPost.js
+++ b/src/components/EditPost.js
@@ -1,61 +1,74 @@
-import React, {useState, useEffect} from "react"
-import {connect} from "react-redux"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
 
-import "../styles/newPost.css"
 import "../styles/buttons.css"
-import {setTempSite} from "../reducers/tempSiteReducer"
-import { changeSitePicture } from "../reducers/postReducer"
-import SiteImageUpload from "./SiteImageUpload"
+import "../styles/postView.css"
+import "../styles/texts.css"
 
 
+import { ReactComponent as Arrow } from "../resources/arrow_back.svg"
+import { ReactComponent as ClearIcon } from "../resources/clear.svg"
 
-export const EditPost = (props) => {
-  const [image, setImage] = useState(null)
+
+export const PostView = (props) => {
+  //gets the post to show based on the id that is set on the url field.
   const post = props.posts.find(item => "" + item.id === props.match.params.id)
-  
-  useEffect(() => {      
-    if(props.tempSite.image){
-      setImage(props.tempSite.image.data
-        )}else{setImage(props.tempSite.image)}
-  }, [props])
 
+  post.uusi = 0
 
-  const cancelClick = (event) => {
+  const changeImage = (postId) =>{
+    props.history.push(`/edit-image/${postId}`)
+  }
+
+  const changeSiteLocation= (postId) => {
+    props.history.push(`/edit-location/${postId}`)
+  }
+
+  const changeSiteTitle= (postId) => {
+    props.history.push(`/edit-title/${postId}`)
+  }
+
+  const closeClick = (event) => {
+    //go back to the previous page
     event.preventDefault()
-    setImage(null)
-    props.setTempSite({"title": "", "location":false, "image": null})
-    props.history.goBack()
+    props.history.push("/")
   }
 
-  const imageOnChangeHandler = (image) => {
-    setImage(image)
+  const backClick = (event) => {
+    //eventhandler for close button
+    event.preventDefault()
+    //console.log("closeClick")
+    props.history.push(`/post-view/${post.id}`)
   }
 
-  const confirmPost = (event) => {
-    event.preventDefault()  
-    props.changeSitePicture(post, image)
-    setImage(null)
-    props.setTempSite({"title": "", "location":false, "image": null})
-    props.history.goBack()
-  }
-
-
-  return(
-    <div className="newPostContainer centerAlignWithPaddingLean">
-    <h1 className="headerText">{props.settings.strings["change_image"]}</h1>
-	<div>
-      <form className="postForm" onSubmit={confirmPost}>
-        <div className="inputContainer">
-        <SiteImageUpload  change={imageOnChangeHandler}/>
+  if(props.user && (post.own === true || props.currentProject.moderators.find(user => user === props.user.username))){
+    return (
+      <div className="userInformationContainer centerAlignWithPaddingContainer">
+        <div className="postTitleContainer"> 
+        
+        <div className="postCloseButtonContainer">
+          <Arrow className="clearIcon" onClick={backClick}/></div>
+          <h1 className="titleText centerAlignWithPadding">{props.settings.strings["edit_post"]}</h1>
+          <ClearIcon className="clearIcon" onClick={closeClick}/>
         </div>
-        <div className="postFormButtonContainer">
-          <button className="rippleButton positiveButton fillButton">{props.settings.strings["submit"]}</button>
-          <button className="rippleButton negativeButton fillButton" onClick={cancelClick}>{props.settings.strings["cancel"]}</button>
+          <div className="userInfoButtonsContainer">
+            <button className="rippleButton" onClick={() => changeImage(post.id)}>{props.settings.strings["change_image"]}</button>
+            <button className="rippleButton" onClick={() => changeSiteTitle(post.id)}>{props.settings.strings["change_title"]}</button>
+            <button className="rippleButton" onClick={() => changeSiteLocation(post.id)}>{props.settings.strings["change_location"]}</button>
+          </div>
+      </div>
+    );
+  }
+  else {
+    return (
+      <div className="userInformationContainer centerAlignWithPaddingContainer">
+        <div className="postTitleContainer">
+          <h1 className="titleText centerAlignWithPadding">{props.settings.strings["no_permission"]}</h1>
+          <ClearIcon className="clearIcon" onClick={closeClick}/>
         </div>
-      </form>
-	</div>
-    </div>
-  )
+      </div>
+    );
+  }
 
 }
 
@@ -63,20 +76,20 @@ const mapStateToProps = (state) => {
   return {
     //maps state to props, after this you can for example call props.notification
     user: state.user,
-    tempSite: state.tempSite,
-    projects: state.projects,
+    posts: state.posts,
     settings: state.settings,
-    posts: state.posts
+    currentProject: state.projects.active
+
   }
 }
 
 const mapDispatchToProps = {
   //connect reducer functions/dispatchs to props
-  setTempSite,
-  changeSitePicture
+  //notify (for example)
+  notify
 }
 
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(EditPost)
+)(PostView)

--- a/src/components/EditSiteTitle.js
+++ b/src/components/EditSiteTitle.js
@@ -1,0 +1,63 @@
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
+
+import { ChangeSiteTitle } from "../reducers/postReducer"
+import "../styles/buttons.css"
+import "../styles/newPost.css"
+
+
+
+export const EditSiteTitle = (props) => {
+  const post = props.posts.find(item => "" + item.id === props.match.params.id)
+
+  const ConfirmNewTitle = (event) => {
+    event.preventDefault()
+    if(event.target.newTitle.value === "")
+    {
+       props.notify(props.settings.strings["no_new_changes"], false, 5)
+    }
+    else {
+      props.ChangeSiteTitle(post, event.target.newTitle.value)
+    }
+    props.history.push(`/edit-post/${post.id}`)
+  }
+
+  return(
+    <div className="userSettingsContainer centerAlignWithPadding">
+        <div className="titleContainer">
+          <h1 className="titleText">{props.settings.strings["change_title"]}</h1>
+        </div>
+        <form className="userSettingsForm" onSubmit={ConfirmNewTitle}>
+          <div className="inputContainer">
+            <input name="newTitle" className="input" placeholder={post.title !== null? post.title : "New Title"} maxLength="200"/>
+            <div className="inputFocusLine"/>
+          </div>
+
+          <div className="dualButtonContainer">
+            <button type="submit" className="positiveButton rippleButton fillButton">{props.settings.strings["confirm"]}</button>
+            <button type="button" className="negativeButton rippleButton fillButton" onClick={() => props.history.push(`/edit-post/${post.id}`)}>{props.settings.strings["cancel"]}</button>
+          </div>
+        </form>
+      </div>
+  )
+
+}
+
+const mapStateToProps = (state) => {
+  return {
+    //maps state to props, after this you can for example call props.notification
+    settings: state.settings,
+    posts: state.posts
+  }
+}
+
+const mapDispatchToProps = {
+  //connect reducer functions/dispatchs to props
+  notify,
+  ChangeSiteTitle
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(EditSiteTitle)

--- a/src/components/FloatingSearch.js
+++ b/src/components/FloatingSearch.js
@@ -1,14 +1,14 @@
 // By: Niklas Impiö
-import React, {useState} from "react"
-import {connect} from "react-redux"
+import { useState } from "react"
+import { connect } from "react-redux"
 import useComponentVisible from "../hooks/OutsideClick"
 
 import "../styles/floatingSearch.css"
 import "../styles/inputs.css"
 
 
+import { ReactComponent as ClearIcon } from "../resources/clear.svg"
 import PostList from "./PostList"
-import {ReactComponent as ClearIcon} from "../resources/clear.svg"
 
 
 

--- a/src/components/HorizontalMenuList.js
+++ b/src/components/HorizontalMenuList.js
@@ -1,20 +1,19 @@
 // By: Niklas Impiö
-import React from "react"
-import {connect} from "react-redux"
-import {logout,logoutS} from "../reducers/loginReducer"
-import {notify} from "../reducers/notificationReducer"
-import {initPosts} from "../reducers/postReducer"
+import { connect } from "react-redux"
+import { logout, logoutS } from "../reducers/loginReducer"
+import { notify } from "../reducers/notificationReducer"
+import { initPosts } from "../reducers/postReducer"
 
 
-import "../styles/horizontalMenuList.css"
 import useComponentVisible from "../hooks/OutsideClick"
+import "../styles/horizontalMenuList.css"
 
+import { ReactComponent as DropDownIcon } from "../resources/arrow_drop_down-24px.svg"
+import { ReactComponent as PersonIcon } from "../resources/person.svg"
 import DropDownList from "./DropDownList"
-import {ReactComponent as DropDownIcon} from "../resources/arrow_drop_down-24px.svg"
-import {ReactComponent as PersonIcon} from "../resources/person.svg"
-import ThemeToggleSwitch from "./ThemeToggleSwitch"
-import NameToggleSwitch from "./NameToggleSwitch"
 import LanguageDropDown from "./LanguageDropDown"
+import NameToggleSwitch from "./NameToggleSwitch"
+import ThemeToggleSwitch from "./ThemeToggleSwitch"
 
 
 const HorizontalMenuList = (props) => {

--- a/src/components/ImageUpload.js
+++ b/src/components/ImageUpload.js
@@ -1,9 +1,9 @@
 //by Niklas Impiö
-import React, {useState, useEffect} from "react"
-import {connect} from "react-redux"
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
 
-import {notify} from "../reducers/notificationReducer"
-import {setTempPost} from "../reducers/tempPostReducer"
+import { notify } from "../reducers/notificationReducer"
+import { setTempPost } from "../reducers/tempPostReducer"
 
 import "../styles/imageUpload.css"
 

--- a/src/components/ImagelessPosts.js
+++ b/src/components/ImagelessPosts.js
@@ -1,12 +1,11 @@
-import React from "react"
-import {connect} from "react-redux"
-import {notify} from "../reducers/notificationReducer"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
 
-import "../styles/myPosts.css"
+import { ReactComponent as ClearIcon } from "../resources/clear.svg"
+import { getImageURL } from "../services/images"
 import "../styles/buttons.css"
+import "../styles/myPosts.css"
 import "../styles/texts.css"
-import {getImageURL} from "../services/images";
-import {ReactComponent as ClearIcon} from "../resources/clear.svg"
 
 
 export const ImagelessPosts = (props) => {

--- a/src/components/LanguageDropDown.js
+++ b/src/components/LanguageDropDown.js
@@ -1,13 +1,13 @@
 // By: Niklas Impiö
-import React, {useState} from "react"
-import {connect} from "react-redux"
+import { useState } from "react"
+import { connect } from "react-redux"
 import useComponentVisible from "../hooks/OutsideClick"
 
-import DropDownList from "./DropDownList"
-import {ReactComponent as DropDownIcon} from "../resources/arrow_drop_down-24px.svg"
+import { ReactComponent as DropDownIcon } from "../resources/arrow_drop_down-24px.svg"
 import "../styles/languageDropDown.css"
+import DropDownList from "./DropDownList"
 
-import {setActiveLanguage} from "../reducers/settingsReducer"
+import { setActiveLanguage } from "../reducers/settingsReducer"
 
 
 

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -1,15 +1,15 @@
 // By: Niklas Impiö
-import React, {useState, useEffect} from "react"
-import {connect} from "react-redux"
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
 
-import {logout} from "../reducers/loginReducer"
-import {notify} from "../reducers/notificationReducer"
+import { logout } from "../reducers/loginReducer"
+import { notify } from "../reducers/notificationReducer"
 
 
 import "../styles/listView.css"
 import "../styles/postView.css"
-import PostViewLW from "./PostViewLW"
 import PostList from "./PostList"
+import PostViewLW from "./PostViewLW"
 
 
 

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -33,8 +33,8 @@ export const LoginForm = (props) => {
 
     if (loginSuccessful) {
         return (
-            <div className="loginContainer centerAlignWithPadding">
-                <h1 className="headerText BottomPadding30">{props.settings.strings["login_or_register"]}</h1>
+            <div className="loginContainer centerAlignWithPaddingContainer">
+                <h1 className="headerText2 BottomPadding30">{props.settings.strings["login_or_register"]}</h1>
                 <div className="normalText textCenter bottomPadding30">{props.settings.strings["link_info"]}</div>
                 <div className="postFormButtonContainer">
                     <button className="positiveButton rippleButton fillButton" onClick={cancelClick}>{props.settings.strings["continue"]}</button>
@@ -44,8 +44,8 @@ export const LoginForm = (props) => {
     }
 
     return (
-        <div className="loginContainer centerAlignWithPadding">
-            <h1 className="headerText bottomPadding30">{props.settings.strings["login_or_register"]}</h1>
+        <div className="loginContainer centerAlignWithPaddingContainer">
+            <h1 className="headerText2 bottomPadding30">{props.settings.strings["login_or_register"]}</h1>
 {/*             TODO: fix social media integration             
 
                 <div className="signUpTitleContainer">

--- a/src/components/MapContainerOpen.js
+++ b/src/components/MapContainerOpen.js
@@ -1,17 +1,17 @@
 // By: Niklas Impiö, Lassi Tölli
-import React, {useState, useEffect, useRef} from "react"
-import {connect} from "react-redux"
-import {MapContainer, TileLayer, Marker, useMapEvents, useMap,Popup} from "react-leaflet"
-import MarkerClusterGroup from "react-leaflet-markercluster"
 import L from "leaflet"
-import "../styles/mapContainer.css"
 import "leaflet/dist/leaflet.css"
-import "../styles/buttons.css"
-import "../styles/markerCluster.css"
-import "../styles/popupContainer.css"
+import { useEffect, useRef, useState } from "react"
+import { MapContainer, Marker, Popup, TileLayer, useMap, useMapEvents } from "react-leaflet"
+import MarkerClusterGroup from "react-leaflet-markercluster"
+import { connect } from "react-redux"
+import iconGreen from "../resources/marker-green.png"
 import icon from "../resources/marker-icon.png"
 import iconShadow from "../resources/marker-shadow.png"
-import iconGreen from "../resources/marker-green.png"
+import "../styles/buttons.css"
+import "../styles/mapContainer.css"
+import "../styles/markerCluster.css"
+import "../styles/popupContainer.css"
 //import iconN from "../resources/marker-icon-new.png"
 //import iconT from "../resources/marker-transp.png"
 //import iconTN from "../resources/marker-transp-new.png"
@@ -28,15 +28,15 @@ import iconGreen from "../resources/marker-green.png"
 //import iconx2 from "../resources/marker-icon-2x.png"
 //import iconPShadow from "../resources/marker-piippu-shadow.png"
 
-import userIconMarker from "../resources/user_icon_custom.svg"
 import tempIconMarker from "../resources/temp_marker.svg"
+import userIconMarker from "../resources/user_icon_custom.svg"
 
-import {notify} from "../reducers/notificationReducer"
-import {createSite} from "../reducers/postReducer"
-import {updateUserLocation} from "../reducers/userLocationReducer"
-import {usePosition} from "../hooks/LocationHook"
-import {setTempSite} from "../reducers/tempSiteReducer"
-import {updateMapLocation} from "../reducers/mapLocationReducer"
+import { usePosition } from "../hooks/LocationHook"
+import { updateMapLocation } from "../reducers/mapLocationReducer"
+import { notify } from "../reducers/notificationReducer"
+import { createSite } from "../reducers/postReducer"
+import { setTempSite } from "../reducers/tempSiteReducer"
+import { updateUserLocation } from "../reducers/userLocationReducer"
 import FloatingSearch from "./FloatingSearch"
 
 var IconMarker = L.Icon.extend({
@@ -92,7 +92,7 @@ const MapContainerOpen = (props) => {
       setPosts(props.posts)
     }
     if(props.mapLocation !== null){
-      setZoom(13)
+      setZoom(18)
       setPosition(props.mapLocation) 
       props.updateMapLocation(null)
       setmoveToPosition(true)
@@ -153,6 +153,7 @@ const MapContainerOpen = (props) => {
       zoomend: (e) => {
         setZoom(map.getZoom())
         setTempMarker(null)
+        console.log(zoom);
       }
     });
     return null;
@@ -208,7 +209,7 @@ const MapContainerOpen = (props) => {
           for(i=0; i < visible.length; i++){  
         loop2:
             for(j=0; j < visible.length; j++){  
-              if(i!=j && visible.length > 1){
+              if(i !== j && visible.length > 1){
                 if (map.latLngToLayerPoint(visible[i].getLatLng()).distanceTo(map.latLngToLayerPoint(visible[j].getLatLng())) < 125) { continue loop1; }
               }
             }
@@ -226,6 +227,7 @@ const MapContainerOpen = (props) => {
         <TileLayer
           attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          
         />
         <UpdateMapCenter/>
         <HandleMapEvents/>
@@ -294,8 +296,7 @@ const MapContainerOpen = (props) => {
       </MapContainer>
       <div className="floatingSearchContainerMap">
         <FloatingSearch history={props.history}/>
-      </div>test site 9e1767bd1bce892ccef23e2f0ab76faef0820e45b5433210bf5f9bfda453ba393edf602afc40c350f37fbc0652972037cc14
-test site 
+      </div>
       <button className="overlayButtonLeft rippleButton" onClick={toListView}>{props.settings.strings["list_view"]}</button>
       {tempMarker ?  props.user ? props.currentProject.id !== "parantolat"? !followUser?
       <button className="overlayButtonCenter pulsingButton rippleButton smallButton" onClick={confirmNewLocationMarker}>{props.settings.strings["new_post"]}</button>

--- a/src/components/MyPosts.js
+++ b/src/components/MyPosts.js
@@ -1,14 +1,13 @@
 // By: Niklas Impiö
-import React from "react"
-import {connect} from "react-redux"
-import {notify} from "../reducers/notificationReducer"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
 
-import "../styles/myPosts.css"
+import { ReactComponent as ClearIcon } from "../resources/clear.svg"
+import { getImageURL } from "../services/images"
 import "../styles/buttons.css"
-import "../styles/texts.css"
-import {getImageURL} from "../services/images";
-import {ReactComponent as ClearIcon} from "../resources/clear.svg"
+import "../styles/myPosts.css"
 import "../styles/postList.css"
+import "../styles/texts.css"
 
 
 

--- a/src/components/NameToggleSwitch.js
+++ b/src/components/NameToggleSwitch.js
@@ -1,9 +1,8 @@
 // button for toggling site names on and off
-import React, {useState} from "react"
-import {connect} from "react-redux"
+import { useState } from "react"
+import { connect } from "react-redux"
 
-import {setActiveTheme} from "../reducers/settingsReducer"
-import {updatePopups} from "../reducers/popupReducer"
+import { updatePopups } from "../reducers/popupReducer"
 import "../styles/themeToggleSwitch.css"
 
 export const NameToggleSwitch = (props) => {

--- a/src/components/NavMenu.js
+++ b/src/components/NavMenu.js
@@ -1,18 +1,17 @@
 // By: Niklas Impiö
-import React from "react"
 //import React, {useState, useEffect} from "react"
 //useState useEffect not used yet
-import {connect} from "react-redux"
-import {logout} from "../reducers/loginReducer"
-import {notify} from "../reducers/notificationReducer"
+import { connect } from "react-redux"
+import { logout } from "../reducers/loginReducer"
+import { notify } from "../reducers/notificationReducer"
 
 
 import "../styles/navMenu.css"
 
 import HorizontalMenuList from "./HorizontalMenuList"
 
-import {setActiveProject} from "../reducers/projectReducer"
-import {initPosts} from "../reducers/postReducer"
+import { initPosts } from "../reducers/postReducer"
+import { setActiveProject } from "../reducers/projectReducer"
 import DropDownSelectProject from "./DropDownSelectProject"
 
 

--- a/src/components/NewMemento.js
+++ b/src/components/NewMemento.js
@@ -1,14 +1,14 @@
 // By: Niklas Impiö
-import React, {useState, useEffect} from "react"
-import {connect} from "react-redux"
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
 
-import "../styles/newPost.css"
-import "../styles/buttons.css"
+import { notify } from "../reducers/notificationReducer"
+import { getActiveProject } from "../reducers/projectReducer"
+import { setTempPost } from "../reducers/tempPostReducer"
 import * as postService from "../services/posts"
-import {notify} from "../reducers/notificationReducer"
-import {setTempPost} from "../reducers/tempPostReducer"
+import "../styles/buttons.css"
+import "../styles/newPost.css"
 import ImageUpload from "./ImageUpload"
-import {getActiveProject} from "../reducers/projectReducer";
 
 export const NewMemento = (props) => {
   const [titleField, setTitleField] = useState("")

--- a/src/components/NewPostCombined.js
+++ b/src/components/NewPostCombined.js
@@ -1,12 +1,12 @@
 // By: Niklas Impiö
-import React, {useState, useEffect} from "react"
-import {connect} from "react-redux"
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
 
-import "../styles/newPost.css"
+import { notify } from "../reducers/notificationReducer"
+import { createSite } from "../reducers/postReducer"
+import { setTempSite } from "../reducers/tempSiteReducer"
 import "../styles/buttons.css"
-import {createSite} from "../reducers/postReducer"
-import {notify} from "../reducers/notificationReducer"
-import {setTempSite} from "../reducers/tempSiteReducer"
+import "../styles/newPost.css"
 
 import SiteImageUpload from "./SiteImageUpload"
 

--- a/src/components/NewProject.js
+++ b/src/components/NewProject.js
@@ -1,13 +1,13 @@
-import React, {useState} from "react"
-import {connect} from "react-redux"
+import { useState } from "react"
+import { connect } from "react-redux"
 
-import {notify} from "../reducers/notificationReducer"
-import {createProject} from "../reducers/projectReducer"
+import { notify } from "../reducers/notificationReducer"
+import { createProject } from "../reducers/projectReducer"
 
 import "../styles/inputs.css"
 import "../styles/newProject.css"
-import ImageUpload from "./ImageUpload"
 import DropDownSelect from "./DropDownSelect"
+import ImageUpload from "./ImageUpload"
 
 export const NewProject = (props) => {
   const [title, setTitle] = useState("")
@@ -21,18 +21,32 @@ export const NewProject = (props) => {
 
   */
 
+  function generateRandomId(length) {
+    var result = '';
+    var characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    var charactersLength = characters.length;
+    for ( var i = 0; i < length; i++ ) {
+        result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    }
+    return result;
+}
+
   const createNewProjectClick = (event) => {
     event.preventDefault()
+    let new_id = generateRandomId(12)
+    let new_mods = []
+    new_mods.push(props.user.username)
     const object = {
+      "id": new_id,
       "title": title,
       "description": description,
       "contentDescription": contentDescription,
       "visitorPosting": accountForPosting === props.settings.strings["only_users_can_post"],
-      "moderators": [],
+      "moderators": new_mods,
       "image": image
     }
-    props.createProject(object)
-    props.notify(`Project "${object.title}" Created.`, false, 5)
+    props.createProject(new_id, object)
+    props.notify(`Project "${title.title}" Created.`, false, 5)
     props.history.push("/")
 
   }
@@ -71,7 +85,7 @@ export const NewProject = (props) => {
             <div className="inputFocusLine"/>
           </div>
           <div className="inputContainer">
-            <textarea name="description" id="descField" className="input" rows="4" placeholder={props.settings.strings["description"]} maxLength="256" autoComplete="off" onChange={descriptionChangeHandler} value={description}/>
+            <textarea name="description" id="descField" className="input" rows="4" placeholder={props.settings.strings["abstract"]} maxLength="256" autoComplete="off" onChange={descriptionChangeHandler} value={description}/>
             <div className="inputFocusLine"/>
           </div>
           <ImageUpload change={imageOnChangeHandler}/>
@@ -97,7 +111,8 @@ export const NewProject = (props) => {
 const mapStateToProps = (state) => {
   return {
     //maps state to props, after this you can for example call props.notification
-    settings: state.settings
+    settings: state.settings,
+    user: state.user
   }
 }
 

--- a/src/components/Notification.js
+++ b/src/components/Notification.js
@@ -1,7 +1,6 @@
 // By: Niklas Impiö
-import React from "react"
-import {connect} from "react-redux"
-import {cancelNotification} from "../reducers/notificationReducer"
+import { connect } from "react-redux"
+import { cancelNotification } from "../reducers/notificationReducer"
 import "../styles/notification.css"
 
 

--- a/src/components/PopUpContainer.js
+++ b/src/components/PopUpContainer.js
@@ -1,9 +1,8 @@
 // By: Niklas Impiö
-import React from "react"
 
+import { connect } from "react-redux"
+import { updateListView } from "../reducers/listViewReducer"
 import "../styles/containers.css"
-import {updateListView} from "../reducers/listViewReducer"
-import {connect} from "react-redux"
 
 
 const PopUpContainer = (props) => {

--- a/src/components/PostList.js
+++ b/src/components/PostList.js
@@ -2,15 +2,15 @@
 // In the list view handles the left scrollable side
 
 //import React, {useState} from "react"
-import {connect} from "react-redux"
-import { LazyLoadImage} from 'react-lazy-load-image-component'
-import {notify} from "../reducers/notificationReducer"
-import {updateListView} from "../reducers/listViewReducer"
+import { LazyLoadImage } from 'react-lazy-load-image-component'
+import { connect } from "react-redux"
+import { updateListView } from "../reducers/listViewReducer"
+import { notify } from "../reducers/notificationReducer"
 
-import React, {useState, useEffect, useRef} from "react"
+import { useEffect, useRef } from "react"
+import { getImageURL } from "../services/images"
 import "../styles/listView.css"
 import "../styles/postList.css"
-import {getImageURL} from "../services/images";
 
 export const PostList = (props) => {
   const myRef = useRef(props.listView)
@@ -23,15 +23,13 @@ export const PostList = (props) => {
  
 
   useEffect(() => {
-    if(itemsRef != [] && props.listView != 0)
+    if(itemsRef !== [] && props.listView !== 0)
     {
       itemsRef.current[props.listView].scrollIntoView()
       itemsRef.current[props.listView].focus()
       
     }
-
-  
-  }, [])
+  }, [props.listView])
 
   return (
 

--- a/src/components/PostView.js
+++ b/src/components/PostView.js
@@ -1,25 +1,25 @@
 // By: Niklas Impiö
-import React, {useState} from "react"
-import {connect} from "react-redux"
-import {notify} from "../reducers/notificationReducer"
-import {deletePost, toggleVerify, changeSitePicture} from "../reducers/postReducer"
-import {updateMapLocation} from "../reducers/mapLocationReducer"
-import {updateListView} from "../reducers/listViewReducer"
+import { useState } from "react"
+import { connect } from "react-redux"
+import { updateListView } from "../reducers/listViewReducer"
+import { updateMapLocation } from "../reducers/mapLocationReducer"
+import { notify } from "../reducers/notificationReducer"
+import { changeSitePicture, deletePost, toggleVerify } from "../reducers/postReducer"
 
-import "../styles/postView.css"
 import "../styles/buttons.css"
-import "../styles/texts.css"
 import "../styles/floatingSearch.css"
+import "../styles/postView.css"
 import "../styles/projectInfo.css"
+import "../styles/texts.css"
 
+import { ReactComponent as Arrow } from "../resources/arrow_back.svg"
+import { ReactComponent as FacebookIcon } from "../resources/facebook_icon.svg"
+import { ReactComponent as TwitterIcon } from "../resources/twitter_icon.svg"
+import { ReactComponent as Verified } from "../resources/verified.svg"
 import MementoList from "./MementoList"
-import {ReactComponent as Verified} from "../resources/verified.svg"
-import {ReactComponent as Arrow} from "../resources/arrow_back.svg"
-import {ReactComponent as TwitterIcon} from "../resources/twitter_icon.svg"
-import {ReactComponent as FacebookIcon} from "../resources/facebook_icon.svg"
 //import {ReactComponent as InstagramIcon} from "../resources/instagram_icon.svg"
-import {ReactComponent as ClearIcon} from "../resources/clear.svg"
-import {getImageURL} from "../services/images";
+import { ReactComponent as ClearIcon } from "../resources/clear.svg"
+import { getImageURL } from "../services/images"
 const ReactMarkdown = require('react-markdown')
 
 
@@ -130,6 +130,7 @@ export const PostView = (props) => {
               :
               <p className="normalText">{`${props.settings.strings["by"]}: ${props.settings.strings["anonymous"]}`}</p>
             }
+            <p className="normalText">{`${props.settings.strings["number_of_memories"]}: ${post.muistoja}`}</p>
 
           </div>
           <div className="postButtonsContainer">
@@ -147,13 +148,13 @@ export const PostView = (props) => {
                     :
                     <button className="rippleButton smallButton negativeButton" onClick={verifyClick}>{props.settings.strings["unverify"]}</button>
                   }
-                  <button className="rippleButton Button negativeButton" onClick={() => editPostClick(post.id)}>{props.settings.strings["change_image"]}</button>
+                  <button className="rippleButton Button negativeButton" onClick={() => editPostClick(post.id)}>{props.settings.strings["change_information"]}</button>
                 </div>
                 :
                 (post.own === true? 
                   <div className="postButtonsContainerInner">
                     <button className="rippleButton smallButton negativeButton" onClick={() => setDeleteState(true)}>{props.settings.strings["delete_post"]}</button>
-                    <button className="rippleButton Button negativeButton" onClick={() => editPostClick(post.id)}>{props.settings.strings["change_image"]}</button>
+                    <button className="rippleButton Button negativeButton" onClick={() => editPostClick(post.id)}>{props.settings.strings["change_information"]}</button>
                   </div>
                   :
                   <></>

--- a/src/components/PostViewLW.js
+++ b/src/components/PostViewLW.js
@@ -10,7 +10,7 @@ import "../styles/postView.css"
 import "../styles/buttons.css"
 import "../styles/texts.css"
 
-
+import MementoList from "./MementoList"
 import {ReactComponent as Verified} from "../resources/verified.svg"
 import {ReactComponent as TwitterIcon} from "../resources/twitter_icon.svg"
 import {ReactComponent as FacebookIcon} from "../resources/facebook_icon.svg"
@@ -175,6 +175,9 @@ export const PostViewLW = (props) => {
             <button className="rippleButton fillButton" onClick={showOnMap}>{props.settings.strings["show_on_map"]}</button>        
         </div>
           }
+      <div className="storyContainer">
+	        <MementoList posts={post} history={props.history}/>
+        </div>
       </div>
     )
   }

--- a/src/components/ProjectInfo.js
+++ b/src/components/ProjectInfo.js
@@ -1,13 +1,13 @@
-import React, {useEffect, useState} from "react"
-import {connect} from "react-redux"
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
 
-import {notify} from "../reducers/notificationReducer"
-import "../styles/projectInfo.css"
+import { notify } from "../reducers/notificationReducer"
+import { ReactComponent as ClearIcon } from "../resources/clear.svg"
+import { ReactComponent as SettingIcon } from "../resources/setting_cog.svg"
+import { getImageURL } from "../services/images"
 import "../styles/containers.css"
 import "../styles/postView.css"
-import {ReactComponent as ClearIcon} from "../resources/clear.svg"
-import {ReactComponent as SettingIcon} from "../resources/setting_cog.svg"
-import {getImageURL} from "../services/images";
+import "../styles/projectInfo.css"
 
 const ReactMarkdown = require('react-markdown')
 

--- a/src/components/ProjectManagement.js
+++ b/src/components/ProjectManagement.js
@@ -1,17 +1,18 @@
-import React, {useEffect, useState} from "react"
-import {connect} from "react-redux"
-import {notify} from "../reducers/notificationReducer"
+import { useEffect, useState } from "react"
 import { CSVLink } from "react-csv"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
 
-import {ReactComponent as ClearIcon} from "../resources/clear.svg"
-import "../styles/postView.css"
+import { ReactComponent as ClearIcon } from "../resources/clear.svg"
 import "../styles/accountInfo.css"
+import "../styles/postView.css"
 
 export const ProjectManagement = (props) => {
   //declare some variables
   const [project, setProject] = useState(props.projects.active)
   const [posts, setPosts] = useState(props.posts)
   const [csvData, setCsvData] = useState([])
+  const [moderatorList, setModeratorList] = useState([])
 
   //in useEffect, check if we have some active project, check its posts and update data for csv download
   useEffect(() => {
@@ -24,12 +25,21 @@ export const ProjectManagement = (props) => {
     }
     //if there is no csv data, generate it
     if(csvData.length <= 1){
-      const postsData = [["Project", "Project moderator", "Site ID", "Site title", "Site creator", "Last modifier", "Memories", "Location latitude", "Location longitude", "Abstract"]]
+      const postsData = [["Project", "Project moderators", "Site ID", "Site title", "Site creator", "Last modifier", "Memories", "Location latitude", "Location longitude", "Abstract"]]
       posts.map((post) => postsData.push([project.title, project.moderators, post.id, post.title, post.creator, post.modifier, post.muistoja, post.location.lat, post.location.lng, post.abstract]))
       //update data to csvData variable
       setCsvData(postsData)
     }
-  }, [props, project.title, posts, csvData.length, project.moderators])
+    //initialize new list of moderators with ',' between items for display purposes
+    if (moderatorList.length <= 1) {
+      const modlist = []
+      project.moderators.map((value) => modlist.push(value + ", "))
+      //remove ',' from last item and add it back
+      let lastItem = modlist.pop().slice(0, -2)
+      modlist.push(lastItem)
+      setModeratorList(modlist)
+    }
+  }, [props, project.title, posts, csvData.length, project.moderators, moderatorList.length])
 
   const closeClick = (event) => {
     //go back to the previous page
@@ -43,9 +53,15 @@ export const ProjectManagement = (props) => {
     props.history.push("/project-settings")
   }
 
+  const addModeratorClick = (event) => {
+    //go to moderator settings page
+    event.preventDefault()
+    props.history.push("/project-moderators")
+  }
+
   if(props.user && project.moderators.find(user => user === props.user.username)){
     return (
-      <div className="userInformationContainer centerAlignWithPadding">
+      <div className="userInformationContainer centerAlignWithPaddingContainer">
         <div className="postTitleContainer">
           <h1 className="titleText centerAlignWithPadding">{props.settings.strings["project_management"]}</h1>
           <ClearIcon className="clearIcon" onClick={closeClick}/>
@@ -63,7 +79,7 @@ export const ProjectManagement = (props) => {
                 </tr>
                 <tr className="userInfoRows">
                   <th className="userInfoValues">{props.settings.strings["project_mod"]}</th>
-                  <th className="userInfoValues">{project.moderators !== null ? project.moderators : "-"}</th>
+                  <th className="userInfoValues">{project.moderators !== null ? moderatorList : "-"}</th>
                 </tr>
                 <tr className="userInfoRows">
                   <th className="userInfoValues">{props.settings.strings["project_sites"]}</th>
@@ -82,6 +98,7 @@ export const ProjectManagement = (props) => {
           </div>
           <div className="userInfoButtonsContainer">
           <button className="rippleButton" onClick={changeProjectInfo}>{props.settings.strings["change_information"]}</button>
+          <button className="rippleButton" onClick={addModeratorClick}>{props.settings.strings["add_new_moderator"]}</button>
           <CSVLink
                 data={csvData}
                 filename={project.id + '-sites.csv'}
@@ -97,7 +114,7 @@ export const ProjectManagement = (props) => {
     return (
       <div className="userInformationContainer centerAlignWithPadding">
         <div className="postTitleContainer">
-          <h1 className="titleText centerAlignWithPadding" onClick={() => props.history.push("/login")}>{props.settings.strings["login_or_register"]}</h1>
+          <h1 className="titleText centerAlignWithPadding">{props.settings.strings["not_moderator"]}</h1>
           <ClearIcon className="clearIcon" onClick={closeClick}/>
         </div>
       </div>

--- a/src/components/ProjectModerators.js
+++ b/src/components/ProjectModerators.js
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
+import { addNewModerator } from "../reducers/projectReducer"
+import { ReactComponent as ClearIcon } from "../resources/clear.svg"
+import "../styles/userSettings.css"
+
+export const ProjectModerators = (props) => {
+  const [project, setProject] = useState(props.projects.active)
+
+  //in useEffect, check if we have some active project
+  useEffect(() => {
+    if(!project.title){
+      setProject(props.projects.active)
+    }
+  }, [props, project.title])
+
+  const modifyConfirmClick = async (event) => {
+    //replace hashtags with %23, because url can't read hashtags in usernames correctly
+    let new_mod = event.target.new_moderator.value.replace(/#/g, "%23")
+    event.preventDefault()
+    //if inputted username isn't empty, try to add it as a new moderator
+    if(event.target.new_moderator.value !== "") {
+      props.addNewModerator(project.id, new_mod)
+      props.notify(props.settings.strings["project_modify_ok"], false, 8)
+    }
+    //if it is empty, notificate user that no new changes to make
+    else {
+      props.notify(props.settings.strings["no_new_changes"], false, 5)
+    }
+    props.history.push("/project-management")
+  }
+
+  if(props.user && project.moderators.find(user => user === props.user.username)){
+    return(
+      <div className="userSettingsContainer centerAlignWithPaddingContainer">
+        <div className="titleContainer">
+          <h1 className="titleText">{props.settings.strings["add_new_moderator"]}</h1>
+        </div>
+        <form className="userSettingsForm" onSubmit={modifyConfirmClick}>
+          <div>
+            <div className="infoTextContainer">
+              <p className="normalText">{props.settings.strings["new_moderator_instructions"]}</p>
+            </div>
+            <div className="inputContainer">
+              <input name="new_moderator" className="input" placeholder={props.settings.strings["new_mod_placeholder"]} maxLength="150"/>
+              <div className="inputFocusLine"/>
+            </div>
+          </div>
+
+          <div className="dualButtonContainer">
+            <button type="submit" className="positiveButton rippleButton fillButton">{props.settings.strings["confirm"]}</button>
+            <button type="button" className="negativeButton rippleButton fillButton" onClick={() => props.history.push("/project-management")}>{props.settings.strings["cancel"]}</button>
+          </div>
+        </form>
+      </div>
+    )
+  }
+  else {
+    return (
+      <div className="userInformationContainer centerAlignWithPaddingContainer">
+        <div className="postTitleContainer">
+          <h1 className="titleText centerAlignWithPadding">{props.settings.strings["not_moderator"]}</h1>
+          <ClearIcon className="clearIcon" onClick={() => props.history.push("/")}/>
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    projects: state.projects,
+    settings: state.settings,
+    user: state.user
+  }
+}
+
+const mapDispatchToProps = {
+  notify, 
+  addNewModerator
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ProjectModerators)

--- a/src/components/ProjectSettings.js
+++ b/src/components/ProjectSettings.js
@@ -1,9 +1,9 @@
-import React, {useEffect, useState} from "react"
-import {connect} from "react-redux"
-import { changeProjectSettings} from "../reducers/projectReducer"
-import {notify} from "../reducers/notificationReducer"
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
+import { changeProjectSettings } from "../reducers/projectReducer"
+import { ReactComponent as ClearIcon } from "../resources/clear.svg"
 import "../styles/userSettings.css"
-import {ReactComponent as ClearIcon} from "../resources/clear.svg"
 
 export const ProjectSettings = (props) => {
   const [project, setProject] = useState(props.projects.active)
@@ -26,19 +26,12 @@ export const ProjectSettings = (props) => {
     let new_title = project.title
     let new_abs = project.description
     let new_desc = project.contentDescription
-    //set default language to the language that the user has chosen on website
-    let new_lang = props.settings.activeLanguage
-    if(event.target.project_title.value === "" && event.target.project_abstract.value === "" && event.target.project_description.value === "" && event.target.project_language.value === "")
+    if(event.target.project_title.value === "" && event.target.project_abstract.value === "" && event.target.project_description.value === "")
     {
       props.notify(props.settings.strings["no_new_changes"], false, 5)
     }
     else
     {
-      //check that the chosen language is supported
-      if (event.target.project_language.value !== "en" && event.target.project_language.value !== "fi" && event.target.project_language.value !== ""){
-        props.notify(props.settings.strings["invalid_language"], false, 8)
-        props.history.push("/project-management")
-      }
       //replace old value with new value, if new value isn't empty
       if(event.target.project_title.value !== "") {
         new_title = event.target.project_title.value 
@@ -49,12 +42,8 @@ export const ProjectSettings = (props) => {
       if(event.target.project_description.value !== "") {
         new_desc = event.target.project_description.value 
       }
-      if(event.target.project_language.value !== "") {
-        new_lang = event.target.project_language.value 
-      }
       const modifiedProject = {
         "id": project.id,
-        "lang": new_lang,
         "name": new_title,
         "abstract": new_abs,
         "description": new_desc
@@ -67,7 +56,7 @@ export const ProjectSettings = (props) => {
 
   if(props.user && project.moderators.find(user => user === props.user.username)){
     return(
-      <div className="userSettingsContainer centerAlignWithPadding">
+      <div className="userSettingsContainer centerAlignWithPaddingContainer">
         <div className="titleContainer">
           <h1 className="titleText">{props.settings.strings["configure_project"]}</h1>
         </div>
@@ -78,10 +67,6 @@ export const ProjectSettings = (props) => {
             </div>
             <div className="inputContainer">
               <input name="project_title" className="input" placeholder={project.title !== null ?  props.settings.strings["project_title"] + ": " + project.title : props.settings.strings["project_title"]} maxLength="150"/>
-              <div className="inputFocusLine"/>
-            </div>
-            <div className="inputContainer">
-              <input name="project_language" className="input" placeholder={props.settings.strings["choose_language"]} maxLength="2"/>
               <div className="inputFocusLine"/>
             </div>
             <div className="inputContainer">
@@ -104,7 +89,7 @@ export const ProjectSettings = (props) => {
   }
   else {
     return (
-      <div className="userInformationContainer centerAlignWithPadding">
+      <div className="userInformationContainer centerAlignWithPaddingContainer">
         <div className="postTitleContainer">
           <h1 className="titleText centerAlignWithPadding">{props.settings.strings["not_moderator"]}</h1>
           <ClearIcon className="clearIcon" onClick={() => props.history.push("/")}/>

--- a/src/components/ProjectStats.js
+++ b/src/components/ProjectStats.js
@@ -1,8 +1,7 @@
-import React from "react"
 //import React, {useState} from "react"
-import {connect} from "react-redux"
+import { connect } from "react-redux"
 
-import {notify} from "../reducers/notificationReducer"
+import { notify } from "../reducers/notificationReducer"
 
 import "../styles/inputs.css"
 import "../styles/projectStatistics.css"

--- a/src/components/SetUserName.js
+++ b/src/components/SetUserName.js
@@ -1,8 +1,8 @@
-import React, {useState} from "react"
-import {connect} from "react-redux"
-import {changeUsernameReducer} from "../reducers/loginReducer"
-import {initPosts} from "../reducers/postReducer"
-import {notify} from "../reducers/notificationReducer"
+import { useState } from "react"
+import { connect } from "react-redux"
+import { changeUsernameReducer } from "../reducers/loginReducer"
+import { notify } from "../reducers/notificationReducer"
+import { initPosts } from "../reducers/postReducer"
 
 import "../styles/loginForm.css"
 

--- a/src/components/SiteImageUpload.js
+++ b/src/components/SiteImageUpload.js
@@ -1,9 +1,9 @@
-import React, {useState, useEffect} from "react"
-import {connect} from "react-redux"
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
 
-import {notify} from "../reducers/notificationReducer"
+import { notify } from "../reducers/notificationReducer"
 
-import {setTempSite} from "../reducers/tempSiteReducer"
+import { setTempSite } from "../reducers/tempSiteReducer"
 
 import "../styles/imageUpload.css"
 

--- a/src/components/ThemeToggleSwitch.js
+++ b/src/components/ThemeToggleSwitch.js
@@ -1,8 +1,8 @@
 // By: Niklas Impiö
-import React, {useState} from "react"
-import {connect} from "react-redux"
+import { useState } from "react"
+import { connect } from "react-redux"
 
-import {setActiveTheme} from "../reducers/settingsReducer"
+import { setActiveTheme } from "../reducers/settingsReducer"
 
 import "../styles/themeToggleSwitch.css"
 

--- a/src/components/UnverifiedPosts.js
+++ b/src/components/UnverifiedPosts.js
@@ -1,12 +1,11 @@
-import React from "react"
-import {connect} from "react-redux"
-import {notify} from "../reducers/notificationReducer"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
 
-import "../styles/myPosts.css"
+import { ReactComponent as ClearIcon } from "../resources/clear.svg"
+import { getImageURL } from "../services/images"
 import "../styles/buttons.css"
+import "../styles/myPosts.css"
 import "../styles/texts.css"
-import {getImageURL} from "../services/images";
-import {ReactComponent as ClearIcon} from "../resources/clear.svg"
 
 
 export const UnverfiedPosts = (props) => {

--- a/src/components/UserSettings.js
+++ b/src/components/UserSettings.js
@@ -1,8 +1,6 @@
-import React, {useState} from "react"
-import {connect} from "react-redux"
-import { changeUserSettings } from "../reducers/loginReducer"
-import {notify} from "../reducers/notificationReducer"
-import {logout} from "../reducers/loginReducer"
+import { connect } from "react-redux"
+import { changeUserSettings, logout } from "../reducers/loginReducer"
+import { notify } from "../reducers/notificationReducer"
 import "../styles/userSettings.css"
 
 export const UserSettings = (props) => {

--- a/src/componentsMobile/AccountInfoMobile.js
+++ b/src/componentsMobile/AccountInfoMobile.js
@@ -1,8 +1,7 @@
-import React from "react"
-import {connect} from "react-redux"
+import { connect } from "react-redux"
+import { ReactComponent as ReturnIcon } from "../resources/arrow_back.svg"
 import "../styles/accountInfo.css"
 import "../styles/buttons.css"
-import {ReactComponent as ReturnIcon} from "../resources/arrow_back.svg"
 
 export const AccountInfo = (props) => {
     const changeInfo = (event) => {

--- a/src/componentsMobile/ChangeUserNameMobile.js
+++ b/src/componentsMobile/ChangeUserNameMobile.js
@@ -1,8 +1,8 @@
-import React, {useState} from "react"
-import {connect} from "react-redux"
-import {changeUsernameReducer} from "../reducers/loginReducer"
-import {initPosts} from "../reducers/postReducer"
-import {notify} from "../reducers/notificationReducer"
+import { useState } from "react"
+import { connect } from "react-redux"
+import { changeUsernameReducer } from "../reducers/loginReducer"
+import { notify } from "../reducers/notificationReducer"
+import { initPosts } from "../reducers/postReducer"
 import "../styles/loginForm.css"
 
 
@@ -28,7 +28,7 @@ export const ChangeUserNameMobile = (props) => {
 
     return (
         <div className="loginContainerMobile">
-            <h1 className="headerText">{props.settings.strings["set_username"]}</h1>
+            <h1 className="titleTextMobile">{props.settings.strings["set_username"]}</h1>
 
             <form className="loginForm" onSubmit={confirmUser}>
                 <div className="inputContainer">

--- a/src/componentsMobile/ContentAreaMobile.js
+++ b/src/componentsMobile/ContentAreaMobile.js
@@ -1,29 +1,32 @@
 // By: Niklas Impiö
-import React from "react"
-import {connect} from "react-redux"
-import {Route} from "react-router-dom"
+import { connect } from "react-redux"
+import { Route } from "react-router-dom"
 
 import MapContainerMobile from "./MapContainerMobile"
 import NavMenuMobile from "./NavMenuMobile"
 
 
-import {notify} from "../reducers/notificationReducer"
-import PostViewMobile from "./PostViewMobile"
-import LoginFormMobile from "./LoginFormMobile"
-import ListViewMobile from "./ListViewMobile"
-import NewPostMobile from "./NewPostMobile"
-import NewMementoMobile from "./NewMementoMobile"
-import MyPostsMobile from "./MyPostsMobile"
-import ProjectInfoMobile from "./ProjectInfoMobile"
+import { notify } from "../reducers/notificationReducer"
 import AboutMobile from "./AboutMobile"
+import AccountInfoMobile from "./AccountInfoMobile"
+import ChangeUserNameMobile from "./ChangeUserNameMobile"
+import EditImageMobile from "./EditImageMobile"
+import EditLocationMobile from "./EditLocationMobile"
+import EditPostMobile from "./EditPostMobile"
+import EditSiteTitleMobile from "./EditSiteTitleMobile"
+import ListViewMobile from "./ListViewMobile"
+import LoginFormMobile from "./LoginFormMobile"
+import MyPostsMobile from "./MyPostsMobile"
+import NewMementoMobile from "./NewMementoMobile"
+import NewPostMobile from "./NewPostMobile"
+import PostViewMobile from "./PostViewMobile"
+import ProjectInfoMobile from "./ProjectInfoMobile"
+import ProjectManagementMobile from "./ProjectManagementMobile"
+import ProjectModeratorsMobile from "./ProjectModeratorsMobile"
+import ProjectSettingsMobile from "./ProjectSettingsMobile"
+import SetUserNameMobile from "./SetUserNameMobile"
 import UnverifiedPostsMobile from "./UnverifiedPostsMobile"
 import UserSettingsMobile from "./UserSettingsMobile"
-import EditPostMobile from "./EditPostMobile"
-import ChangeUserNameMobile from "./ChangeUserNameMobile"
-import SetUserNameMobile from "./SetUserNameMobile"
-import AccountInfoMobile from "./AccountInfoMobile"
-import ProjectManagementMobile from "./ProjectManagementMobile"
-import ProjectSettingsMobile from "./ProjectSettingsMobile"
 
 const ContentAreaMobile = (props) => {
   // Ok this is just a container component for all the sub components except notification.
@@ -58,6 +61,15 @@ const ContentAreaMobile = (props) => {
       <Route path="/edit-post/:id/" render={({match,history}) => (
           <EditPostMobile match={match} history={history}/>
       )}/>
+      <Route path="/edit-image/:id/" render={({match,history}) => (
+          <EditImageMobile match={match} history={history}/>
+      )}/>
+      <Route path="/edit-title/:id/" render={({match,history}) => (
+          <EditSiteTitleMobile match={match} history={history}/>
+      )}/>
+      <Route path="/edit-location/:id/" render={({match,history}) => (
+          <EditLocationMobile match={match} history={history}/>
+      )}/>
       <Route path="/new-memento/:id/" render={({match,history}) => (
           <NewMementoMobile match={match} history={history}/>
       )}/>
@@ -88,8 +100,11 @@ const ContentAreaMobile = (props) => {
       <Route path="/project-management/" render={({history}) => (
         <ProjectManagementMobile history={history}/>
       )}/>
-            <Route path="/project-settings/" render={({history}) => (
+      <Route path="/project-settings/" render={({history}) => (
         <ProjectSettingsMobile history={history}/>
+      )}/>
+      <Route path="/project-moderators/" render={({history}) => (
+        <ProjectModeratorsMobile history={history}/>
       )}/>
     </div>
   )

--- a/src/componentsMobile/EditImageMobile.js
+++ b/src/componentsMobile/EditImageMobile.js
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
+
+import { changeSitePicture } from "../reducers/postReducer"
+import { setTempSite } from "../reducers/tempSiteReducer"
+import "../styles/buttons.css"
+import "../styles/newPost.css"
+import SiteImageUploadMobile from "./SiteImageUploadMobile"
+
+
+import { ReactComponent as ReturnIcon } from "../resources/arrow_back.svg"
+
+
+//combined new post where everything is in a single window. Toggle buttons for which location selection method chosen.
+// aka if "live location" button is highlighted the it uses your current location. if map button highlighted then it uses selected location.
+
+export const EditImageMobile = (props) => {
+  const [image, setImage] = useState(null)
+  const post = props.posts.find(item => "" + item.id === props.match.params.id)
+
+  useEffect(() => {
+    if(props.tempSite.image){
+      setImage(props.tempSite.image.data
+        )}else{setImage(props.tempSite.image)}
+  }, [props])
+
+
+  const cancelClick = (event) => {
+    event.preventDefault()
+    setImage(null)
+    props.setTempSite({"title": "", "location":false, "image": null})
+    props.history.goBack()
+  }
+
+  const imageOnChangeHandler = (image) => {
+    setImage(image)
+  }
+
+  const confirmPost = (event) => {
+    event.preventDefault()  
+    props.changeSitePicture(post, image)
+    setImage(null)
+    props.setTempSite({"title": "", "location":false, "image": null})
+    props.history.goBack()
+  }
+
+
+  return(
+    <div className="newPostContainerMobile">
+      <div>
+        <div className="titleContainerMobile">
+          <button className="mobileButtonContainer">
+            <ReturnIcon className="mobileIcon" onClick={cancelClick}/>
+          </button>
+          <h1 className="titleTextMobile">{props.settings.strings["change_image"]}</h1>
+        </div>
+
+	<div>
+      		<form className="postFormMobile" onSubmit={confirmPost}>
+      		  <div className="inputContainer">
+              <SiteImageUploadMobile change={imageOnChangeHandler}/>
+      		  </div>
+	        <div className="postFormButtonContainer">
+	          <button className="rippleButton positiveButton fillButton">{props.settings.strings["submit"]}</button>
+	          <button className="rippleButton negativeButton fillButton" onClick={cancelClick}>{props.settings.strings["cancel"]}</button>
+	        </div>
+	      </form>
+	</div>
+        
+      </div>
+    </div>
+  )
+
+}
+
+const mapStateToProps = (state) => {
+  return {
+    //maps state to props, after this you can for example call props.notification
+    user: state.user,
+    tempSite: state.tempSite,
+    projects: state.projects,
+    settings: state.settings,
+    posts: state.posts
+  }
+}
+
+const mapDispatchToProps = {
+  //connect reducer functions/dispatchs to props
+  setTempSite,
+  changeSitePicture
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(EditImageMobile)

--- a/src/componentsMobile/EditLocationMobile.js
+++ b/src/componentsMobile/EditLocationMobile.js
@@ -1,0 +1,121 @@
+import L from "leaflet"
+import { useState } from "react"
+import { MapContainer, Marker, TileLayer, useMapEvents } from "react-leaflet"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
+import { ChangeSiteLocation } from "../reducers/postReducer"
+
+import "leaflet/dist/leaflet.css"
+import { ReactComponent as ReturnIcon } from "../resources/arrow_back.svg"
+import tempIconMarker from "../resources/temp_marker.svg"
+import "../styles/buttons.css"
+import "../styles/mapContainer.css"
+import "../styles/newPost.css"
+
+const tempIcon = L.icon({
+  iconUrl: tempIconMarker,
+  iconAnchor: [16,32]
+})
+
+export const EditLocation = (props) => {
+  const post = props.posts.find(item => "" + item.id === props.match.params.id)
+  const [position, setPosition] = useState({lat: 65.01157565139543, lng: 25.470943450927738})
+  const [tempMarker, setTempMarker] = useState(null)
+  const [newLat, setNewLat] = useState(null)
+  const [newLng, setNewLng] = useState(null)
+
+  const ConfirmNewLocation = (event) => {
+    event.preventDefault()
+    //if input fields were empty
+    if(newLat === null || newLng === null)
+    {
+      props.notify(props.settings.strings["no_new_changes"], false, 5)
+    }
+    //if some new values were entered
+    else {
+      props.ChangeSiteLocation(post, newLat, newLng)
+    }
+    props.history.push(`/edit-post/${post.id}`)
+  }
+
+  //function for handling events on the map
+  const HandleMapEvents = () => {
+    useMapEvents({
+      click: (e) => {
+        if(props.user !== null) {
+          setNewLat(e.latlng.lat)
+          setNewLng(e.latlng.lng)
+          setPosition(e.latlng)
+          setTempMarker(e.latlng)
+        }
+      }
+    });
+    return null;
+  }
+
+  return(
+    <div className="userSettingsContainerMobile">
+        <div className="titleContainerMobile">
+          <button className="mobileButtonContainer">
+            <ReturnIcon className="mobileIcon" onClick={() => props.history.goBack()}/>
+          </button>
+          <div className="titleHeaderMobile">
+            <h1 className="titleTextMobile">{props.settings.strings["choose_new_location"]}</h1>
+          </div>
+        </div>
+        <div className="mapContainerSmallMobile">
+          <MapContainer className="smallMap" center={position} zoom={5}>
+          <TileLayer
+            attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+          <HandleMapEvents/>
+          {tempMarker !== null && props.currentProject.id !== "parantolat"?
+            <Marker position={tempMarker} icon={tempIcon}></Marker>
+            :
+            <></>
+          }
+          </MapContainer>
+        </div>
+        <div className="userInformationMobile">
+          <table>
+            <tbody>
+              <tr className="userInfoRows">
+                <th className="userInfoValues">Latitude</th>
+                <th className="userInfoValues">{newLat !== null? newLat : "-"}</th>
+              </tr>
+              <tr className="userInfoRows">
+                <th className="userInfoValues">Longitude</th>
+                <th className="userInfoValues">{newLng !== null? newLng : "-"}</th>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div className="dualButtonContainer">
+          <button className="positiveButton rippleButton fillButton" onClick={ConfirmNewLocation}>{props.settings.strings["confirm"]}</button>
+          <button className="negativeButton rippleButton fillButton" onClick={() => props.history.push(`/edit-post/${post.id}`)}>{props.settings.strings["cancel"]}</button>
+        </div>
+      </div>
+  )
+
+}
+
+const mapStateToProps = (state) => {
+  return {
+    //maps state to props, after this you can for example call props.notification
+    settings: state.settings,
+    posts: state.posts,
+    currentProject: state.projects.active
+  }
+}
+
+const mapDispatchToProps = {
+  //connect reducer functions/dispatchs to props
+  notify,
+  ChangeSiteLocation
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(EditLocation)

--- a/src/componentsMobile/EditPostMobile.js
+++ b/src/componentsMobile/EditPostMobile.js
@@ -1,76 +1,80 @@
-// By: Niklas Impiö
-import React, {useState, useEffect} from "react"
-import {connect} from "react-redux"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
 
-import "../styles/newPost.css"
 import "../styles/buttons.css"
-import {setTempSite} from "../reducers/tempSiteReducer"
-import { changeSitePicture } from "../reducers/postReducer"
-import SiteImageUploadMobile from "./SiteImageUploadMobile"
+import "../styles/postView.css"
+import "../styles/texts.css"
 
 
-import {ReactComponent as ReturnIcon} from "../resources/arrow_back.svg"
+import { ReactComponent as ReturnIcon } from "../resources/arrow_back.svg"
+import { ReactComponent as ClearIcon } from "../resources/clear.svg"
 
 
-//combined new post where everything is in a single window. Toggle buttons for which location selection method chosen.
-// aka if "live location" button is highlighted the it uses your current location. if map button highlighted then it uses selected location.
-
-export const EditPostMobile = (props) => {
-  const [image, setImage] = useState(null)
+export const PostView = (props) => {
+  //gets the post to show based on the id that is set on the url field.
   const post = props.posts.find(item => "" + item.id === props.match.params.id)
 
-  useEffect(() => {
-    if(props.tempSite.image){
-      setImage(props.tempSite.image.data
-        )}else{setImage(props.tempSite.image)}
-  }, [props])
+  post.uusi = 0
 
+  const changeImage = (postId) =>{
+    props.history.push(`/edit-image/${postId}`)
+  }
 
-  const cancelClick = (event) => {
+  const changeSiteLocation= (postId) => {
+    props.history.push(`/edit-location/${postId}`)
+  }
+
+  const changeSiteTitle= (postId) => {
+    props.history.push(`/edit-title/${postId}`)
+  }
+
+  const closeClick = (event) => {
+    //go back to the previous page
     event.preventDefault()
-    setImage(null)
-    props.setTempSite({"title": "", "location":false, "image": null})
     props.history.push("/")
   }
 
-  const imageOnChangeHandler = (image) => {
-    setImage(image)
+  const backClick = (event) => {
+    event.preventDefault()
+    props.history.push(`/post-view/${post.id}`)
   }
 
-  const confirmPost = (event) => {
-    event.preventDefault()  
-    props.changeSitePicture(post, image)
-    setImage(null)
-    props.setTempSite({"title": "", "location":false, "image": null})
-    props.history.goBack()
-  }
-
-
-  return(
-    <div className="newPostContainerMobile">
-      <div>
-        <div className="titleContainerMobile">
+  if(props.user && (post.own === true || props.currentProject.moderators.find(user => user === props.user.username))){
+    return (
+      <div className="userInformationContainerMobile">
+        <div className="titleContainerMobile"> 
           <button className="mobileButtonContainer">
-            <ReturnIcon className="mobileIcon" onClick={cancelClick}/>
+            <ReturnIcon className="mobileIcon" onClick={backClick}/>
           </button>
-          <h1 className="titleTextMobile">{props.settings.strings["change_image"]}</h1>
+          <div className="titleHeaderMobile">
+            <h1 className="titleTextMobile">{props.settings.strings["edit_post"]}</h1>
+          </div>
+          <button className="mobileButtonContainer">
+            <ClearIcon className="mobileIcon" onClick={closeClick}/>
+          </button>
         </div>
-
-	<div>
-      		<form className="postFormMobile" onSubmit={confirmPost}>
-      		  <div className="inputContainer">
-              <SiteImageUploadMobile change={imageOnChangeHandler}/>
-      		  </div>
-	        <div className="postFormButtonContainer">
-	          <button className="rippleButton negativeButton fillButton" onClick={cancelClick}>{props.settings.strings["cancel"]}</button>
-	          <button className="rippleButton positiveButton fillButton">{props.settings.strings["submit"]}</button>
-	        </div>
-	      </form>
-	</div>
-        
+          <div className="userInfoButtonsContainerMobile">
+            <button className="rippleButton" onClick={() => changeImage(post.id)}>{props.settings.strings["change_image"]}</button>
+            <button className="rippleButton" onClick={() => changeSiteTitle(post.id)}>{props.settings.strings["change_title"]}</button>
+            <button className="rippleButton" onClick={() => changeSiteLocation(post.id)}>{props.settings.strings["change_location"]}</button>
+          </div>
       </div>
-    </div>
-  )
+    );
+  }
+  else {
+    return (
+      <div className="userInformationContainerMobile">
+        <div className="titleContainerMobile">
+        <div className="titleHeaderMobile">
+          <h1 className="titleTextMobile">{props.settings.strings["no_permission"]}</h1>
+        </div>
+        <button className="mobileButtonContainer">
+          <ClearIcon className="mobileIcon" onClick={closeClick}/>
+        </button>
+        </div>
+      </div>
+    );
+  }
 
 }
 
@@ -78,20 +82,19 @@ const mapStateToProps = (state) => {
   return {
     //maps state to props, after this you can for example call props.notification
     user: state.user,
-    tempSite: state.tempSite,
-    projects: state.projects,
+    posts: state.posts,
     settings: state.settings,
-    posts: state.posts
+    currentProject: state.projects.active
   }
 }
 
 const mapDispatchToProps = {
   //connect reducer functions/dispatchs to props
-  setTempSite,
-  changeSitePicture
+  //notify (for example)
+  notify
 }
 
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(EditPostMobile)
+)(PostView)

--- a/src/componentsMobile/EditSiteTitleMobile.js
+++ b/src/componentsMobile/EditSiteTitleMobile.js
@@ -1,0 +1,67 @@
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
+
+import { ChangeSiteTitle } from "../reducers/postReducer"
+import { ReactComponent as ReturnIcon } from "../resources/arrow_back.svg"
+import "../styles/buttons.css"
+import "../styles/newPost.css"
+
+export const EditSiteTitle = (props) => {
+  const post = props.posts.find(item => "" + item.id === props.match.params.id)
+
+  const ConfirmNewTitle = (event) => {
+    event.preventDefault()
+    if(event.target.newTitle.value === "")
+    {
+       props.notify(props.settings.strings["no_new_changes"], false, 5)
+    }
+    else {
+      props.ChangeSiteTitle(post, event.target.newTitle.value)
+    }
+    props.history.push(`/edit-post/${post.id}`)
+  }
+
+  return(
+    <div className="loginContainerMobile">
+        <div className="titleContainerMobile">
+          <button className="mobileButtonContainer">
+            <ReturnIcon className="mobileIcon" onClick={() => props.history.goBack()}/>
+          </button>
+          <div className="titleHeaderMobile">
+            <h1 className="titleTextMobile">{props.settings.strings["change_title"]}</h1>
+          </div>
+        </div>
+        <form className="userSettingsFormMobile" onSubmit={ConfirmNewTitle}>
+          <div className="inputContainer">
+            <input name="newTitle" className="input" placeholder={post.title !== null? post.title : "New Title"} maxLength="200"/>
+            <div className="inputFocusLine"/>
+          </div>
+
+          <div className="dualButtonContainer">
+            <button type="submit" className="positiveButton rippleButton fillButton">{props.settings.strings["confirm"]}</button>
+            <button type="button" className="negativeButton rippleButton fillButton" onClick={() => props.history.push(`/edit-post/${post.id}`)}>{props.settings.strings["cancel"]}</button>
+          </div>
+        </form>
+      </div>
+  )
+
+}
+
+const mapStateToProps = (state) => {
+  return {
+    //maps state to props, after this you can for example call props.notification
+    settings: state.settings,
+    posts: state.posts
+  }
+}
+
+const mapDispatchToProps = {
+  //connect reducer functions/dispatchs to props
+  notify,
+  ChangeSiteTitle
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(EditSiteTitle)

--- a/src/componentsMobile/ImageUploadMobile.js
+++ b/src/componentsMobile/ImageUploadMobile.js
@@ -1,9 +1,9 @@
 //by Niklas Impiö
-import React, {useState, useEffect} from "react"
-import {connect} from "react-redux"
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
 
-import {notify} from "../reducers/notificationReducer"
-import {setTempPost} from "../reducers/tempPostReducer"
+import { notify } from "../reducers/notificationReducer"
+import { setTempPost } from "../reducers/tempPostReducer"
 
 import "../styles/imageUpload.css"
 

--- a/src/componentsMobile/ListViewMobile.js
+++ b/src/componentsMobile/ListViewMobile.js
@@ -1,23 +1,23 @@
 // By: Niklas Impiö
-import React, {useState, useEffect,useRef} from "react"
-import {connect} from "react-redux"
-import {updateListView} from "../reducers/listViewReducer"
-import {logout} from "../reducers/loginReducer"
-import {notify} from "../reducers/notificationReducer"
+import { useEffect, useRef, useState } from "react"
+import { connect } from "react-redux"
+import { updateListView } from "../reducers/listViewReducer"
+import { logout } from "../reducers/loginReducer"
+import { notify } from "../reducers/notificationReducer"
 
 
-import "../styles/listView.css"
-import "../styles/postView.css"
-import "../styles/postList.css"
 import "../styles/buttons.css"
+import "../styles/listView.css"
+import "../styles/postList.css"
+import "../styles/postView.css"
 import "../styles/texts.css"
 
 
 
-import {ReactComponent as AddIcon} from "../resources/add_circle.svg"
-import {ReactComponent as MapViewIcon} from "../resources/map_view_icon.svg"
-import {ReactComponent as ReturnIcon} from "../resources/arrow_back.svg"
-import {getImageURL} from "../services/images";
+import { ReactComponent as AddIcon } from "../resources/add_circle.svg"
+import { ReactComponent as ReturnIcon } from "../resources/arrow_back.svg"
+import { ReactComponent as MapViewIcon } from "../resources/map_view_icon.svg"
+import { getImageURL } from "../services/images"
 
 
 
@@ -31,7 +31,7 @@ export const ListViewMobile = (props) => {
   const itemsRef = useRef([]);
 
   useEffect(() => {
-    if(itemsRef != [] && props.listView != 0)
+    if(itemsRef !== [] && props.listView !== 0)
     {
       console.log(props.listView);
       itemsRef.current[props.listView].scrollIntoView()

--- a/src/componentsMobile/LoginFormMobile.js
+++ b/src/componentsMobile/LoginFormMobile.js
@@ -34,7 +34,7 @@ export const LoginForm = (props) => {
     if (loginSuccessful) {
         return (
             <div className="loginContainerMobile">
-                <h1 className="headerText BottomPadding30">{props.settings.strings["login_or_register"]}</h1>
+                <h1 className="headerText2 BottomPadding30">{props.settings.strings["login_or_register"]}</h1>
                 <div className="normalText textCenter bottomPadding30">{props.settings.strings["link_info"]}</div>
                 <div className="postFormButtonContainer">
                     <button className="positiveButton rippleButton fillButton" onClick={cancelClick}>{props.settings.strings["continue"]}</button>
@@ -44,7 +44,7 @@ export const LoginForm = (props) => {
     }
     return (
         <div className="loginContainerMobile">
-            <h1 className="headerText">{props.settings.strings["login_or_register"]}</h1>
+            <h1 className="headerText2">{props.settings.strings["login_or_register"]}</h1>
     {/*             TODO: fix social media integration             
 
                 <div className="loginForm">

--- a/src/componentsMobile/MapContainerMobile.js
+++ b/src/componentsMobile/MapContainerMobile.js
@@ -1,35 +1,35 @@
 // By: Niklas Impiö, Lassi Tölli
-import React, {useState, useEffect, useRef} from "react"
-import {connect} from "react-redux"
-import {MapContainer, TileLayer, Marker, useMapEvents, useMap, Popup} from "react-leaflet"
-import MarkerClusterGroup from "react-leaflet-markercluster"
 import L from "leaflet"
+import { useEffect, useRef, useState } from "react"
+import { MapContainer, Marker, Popup, TileLayer, useMap, useMapEvents } from "react-leaflet"
+import MarkerClusterGroup from "react-leaflet-markercluster"
+import { connect } from "react-redux"
 
-import "../stylesMobile/mapContainerMobile.css"
 import "leaflet/dist/leaflet.css"
 import "../styles/markerCluster.css"
 import "../styles/popupContainer.css"
+import "../stylesMobile/mapContainerMobile.css"
 
 import icon from "../resources/marker-icon.png"
 //import iconN from "../resources/marker-icon-new.png"
 //import iconT from "../resources/marker-transp.png"
 //import iconTN from "../resources/marker-transp-new.png"
-import iconShadow from "../resources/marker-shadow.png"
 import iconGreen from "../resources/marker-green.png"
+import iconShadow from "../resources/marker-shadow.png"
 
-import userIconMarker from "../resources/user_icon_custom.svg"
+import { ReactComponent as AddIcon } from "../resources/add_circle.svg"
 import tempIconMarker from "../resources/temp_marker.svg"
-import {ReactComponent as AddIcon} from "../resources/add_circle.svg"
-import {ReactComponent as ListViewIcon} from "../resources/view_list.svg"
+import userIconMarker from "../resources/user_icon_custom.svg"
+import { ReactComponent as ListViewIcon } from "../resources/view_list.svg"
 
-import {notify} from "../reducers/notificationReducer"
-import {createSite} from "../reducers/postReducer"
-import {updateUserLocation} from "../reducers/userLocationReducer"
+import { notify } from "../reducers/notificationReducer"
+import { createSite } from "../reducers/postReducer"
+import { updateUserLocation } from "../reducers/userLocationReducer"
 
-import {usePosition} from "../hooks/LocationHook"
-import {setTempSite} from "../reducers/tempSiteReducer"
-import {updateMapLocation} from "../reducers/mapLocationReducer"
 import FloatingSearch from "../components/FloatingSearch"
+import { usePosition } from "../hooks/LocationHook"
+import { updateMapLocation } from "../reducers/mapLocationReducer"
+import { setTempSite } from "../reducers/tempSiteReducer"
 
 var IconMarker = L.Icon.extend({
         options: {
@@ -87,7 +87,7 @@ const MapContainerMobile = (props) => {
     }
 
     if(props.mapLocation !== null){
-      setZoom(13)
+      setZoom(18)
       setPosition(props.mapLocation)
       props.updateMapLocation(null)
       setmoveToPosition(true)
@@ -203,7 +203,7 @@ const MapContainerMobile = (props) => {
           for(i=0; i < visible.length; i++){  
         loop2:
             for(j=0; j < visible.length; j++){  
-              if(i!=j && visible.length > 1){
+              if(i !== j && visible.length > 1){
                 if (map.latLngToLayerPoint(visible[i].getLatLng()).distanceTo(map.latLngToLayerPoint(visible[j].getLatLng())) < 110) { continue loop1; }
               }
             }

--- a/src/componentsMobile/MementoListMobile.js
+++ b/src/componentsMobile/MementoListMobile.js
@@ -1,18 +1,18 @@
-import { useEffect, useState } from "react"
-import { connect } from "react-redux"
+import React, {useState, useEffect} from "react"
+import {connect} from "react-redux"
 
 
-import { notify } from "../reducers/notificationReducer"
 import * as postService from "../services/posts"
+import {notify} from "../reducers/notificationReducer"
 
-import { deleteMemory, toggleVerifyMemento } from "../reducers/postReducer"
-import { getImageURL } from "../services/images"
 import "../styles/listView.css"
 import "../styles/postList.css"
 import "../styles/postView.css"
+import {getImageURL} from "../services/images"
+import { deleteMemory, toggleVerifyMemento } from "../reducers/postReducer"
 
 
-export const MementoList = (props) => {
+export const MementoListMobile = (props) => {
   const [mementos, setMementos] = useState([])
   //boolean for checking, if user has clicked delete memory
   const [deleteState, setDeleteState] = useState(false)
@@ -70,29 +70,29 @@ export const MementoList = (props) => {
               <img className="postListImagePreview" src={getImageURL("placeholder.jpg")} alt=""></img>
             </div>
             <div className="postListItemInfo">
-              <h2 className="postListTitle">{`${props.settings.strings["add_your_memento"]}`}</h2>
+              
               <p className="normalText">{`${props.settings.strings["add_your_memento_info"]}`}</p>
             </div>
           </li>
         {mementos.map((memento,index) =>
-            <li key={index} className="postListItem">
+            <li key={index} className="postListItemMobile">
               <div className="postListItemImageContainer">
-                <img className="postListImagePreview" src={getImageURL(memento.image)} alt=""></img>   
+                <img className="postListImagePreview" src={getImageURL(memento.image)} alt=""></img>  
+                <h2 className="postListTitleMobile">{memento.title}</h2> 
               </div>
               <div className="postListItemInfo">  
-                <h2 className="postListTitle">{memento.title}</h2>
                 {props.user?
                 (props.currentProject.moderators.find(user => user === props.user.username)?
                 <div className="postButtonsContainerInner">
-                  {memento.waiting_approval?             
-                  <button className="rippleButton Button negativeButton" onClick={() => verifyClickMemento(memento)}>{props.settings.strings["verify"]}</button>
-                  :
-                  <button className="rippleButton Button negativeButton" onClick={() => verifyClickMemento(memento)}>{props.settings.strings["unverify"]}</button>
-                  }
-                  </div>
-                  : <div/>)
-                  :
-                  <></>}
+                {memento.waiting_approval?             
+                <button className="rippleButton Button negativeButton" onClick={() => verifyClickMemento(memento)}>{props.settings.strings["verify"]}</button>
+                :
+                <button className="rippleButton Button negativeButton" onClick={() => verifyClickMemento(memento)}>{props.settings.strings["unverify"]}</button>
+                }
+                </div>
+                : <div/>)
+                :
+                <></>}
                 <p className="normalText">{memento.story}</p>
                 {props.user? 
                 memento.own === true?
@@ -137,4 +137,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(MementoList)
+)(MementoListMobile)

--- a/src/componentsMobile/MyPostsMobile.js
+++ b/src/componentsMobile/MyPostsMobile.js
@@ -1,15 +1,14 @@
 // By: Niklas Impiö
-import React from "react"
-import {connect} from "react-redux"
-import {notify} from "../reducers/notificationReducer"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
 
-import "../styles/myPosts.css"
 import "../styles/buttons.css"
+import "../styles/myPosts.css"
 import "../styles/texts.css"
 
 
-import {ReactComponent as ReturnIcon} from "../resources/arrow_back.svg"
-import {getImageURL} from "../services/images";
+import { ReactComponent as ReturnIcon } from "../resources/arrow_back.svg"
+import { getImageURL } from "../services/images"
 
 
 

--- a/src/componentsMobile/NavMenuMobile.js
+++ b/src/componentsMobile/NavMenuMobile.js
@@ -1,20 +1,20 @@
 // By: Niklas Impiö
-import React, {useState} from "react"
-import {connect} from "react-redux"
-import {logout,logoutS} from "../reducers/loginReducer"
-import {notify} from "../reducers/notificationReducer"
+import { useState } from "react"
+import { connect } from "react-redux"
+import { logout, logoutS } from "../reducers/loginReducer"
+import { notify } from "../reducers/notificationReducer"
 
 
+import { ReactComponent as MenuIcon } from "../resources/menu.svg"
 import "../styles/navMenu.css"
 import "../stylesMobile/navMenuMobile.css"
-import {ReactComponent as MenuIcon} from "../resources/menu.svg"
 
-import LanguageDropDown from "../components/LanguageDropDown"
-import ThemeToggleSwitch from "../components/ThemeToggleSwitch"
 import DropDownSelectProject from "../components/DropDownSelectProject"
-import {setActiveProject} from "../reducers/projectReducer"
-import {initPosts} from "../reducers/postReducer"
+import LanguageDropDown from "../components/LanguageDropDown"
 import NameToggleSwitch from "../components/NameToggleSwitch"
+import ThemeToggleSwitch from "../components/ThemeToggleSwitch"
+import { initPosts } from "../reducers/postReducer"
+import { setActiveProject } from "../reducers/projectReducer"
 
 
 export const NavMenuMobile = (props) => {

--- a/src/componentsMobile/NewMementoMobile.js
+++ b/src/componentsMobile/NewMementoMobile.js
@@ -1,15 +1,15 @@
-import React, {useState, useEffect} from "react"
-import {connect} from "react-redux"
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
 
-import "../styles/newPost.css"
-import "../styles/buttons.css"
+import { notify } from "../reducers/notificationReducer"
+import { setTempPost } from "../reducers/tempPostReducer"
 import * as postService from "../services/posts"
-import {notify} from "../reducers/notificationReducer"
-import {setTempPost} from "../reducers/tempPostReducer"
+import "../styles/buttons.css"
+import "../styles/newPost.css"
 import ImageUploadMobile from "./ImageUploadMobile"
 
-import {ReactComponent as ReturnIcon} from "../resources/arrow_back.svg"
-import {getActiveProject} from "../reducers/projectReducer";
+import { getActiveProject } from "../reducers/projectReducer"
+import { ReactComponent as ReturnIcon } from "../resources/arrow_back.svg"
 
 
 //combined new post where everything is in a single window. Toggle buttons for which location selection method chosen.

--- a/src/componentsMobile/NewPostMobile.js
+++ b/src/componentsMobile/NewPostMobile.js
@@ -1,16 +1,16 @@
 // By: Niklas Impiö
-import React, {useState, useEffect} from "react"
-import {connect} from "react-redux"
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
 
-import "../styles/newPost.css"
+import { notify } from "../reducers/notificationReducer"
+import { createSite } from "../reducers/postReducer"
+import { setTempSite } from "../reducers/tempSiteReducer"
 import "../styles/buttons.css"
-import {createSite} from "../reducers/postReducer"
-import {notify} from "../reducers/notificationReducer"
-import {setTempSite} from "../reducers/tempSiteReducer"
+import "../styles/newPost.css"
 import SiteImageUploadMobile from "./SiteImageUploadMobile"
 
 
-import {ReactComponent as ReturnIcon} from "../resources/arrow_back.svg"
+import { ReactComponent as ReturnIcon } from "../resources/arrow_back.svg"
 
 
 //combined new post where everything is in a single window. Toggle buttons for which location selection method chosen.

--- a/src/componentsMobile/NotificationMobile.js
+++ b/src/componentsMobile/NotificationMobile.js
@@ -1,7 +1,6 @@
 // By: Niklas Impiö
-import React from "react"
-import {connect} from "react-redux"
-import {cancelNotification} from "../reducers/notificationReducer"
+import { connect } from "react-redux"
+import { cancelNotification } from "../reducers/notificationReducer"
 import "../styles/notification.css"
 
 

--- a/src/componentsMobile/PostViewMobile.js
+++ b/src/componentsMobile/PostViewMobile.js
@@ -9,14 +9,16 @@ import "../styles/postView.css"
 import "../styles/buttons.css"
 import "../styles/texts.css"
 
-import MementoList from "../components/MementoList"
+
 
 import {ReactComponent as Verified} from "../resources/verified.svg"
 import {ReactComponent as ReturnIcon} from "../resources/arrow_back.svg"
+import {ReactComponent as ClearIcon} from "../resources/clear.svg"
 import {ReactComponent as TwitterIcon} from "../resources/twitter_icon.svg"
 import {ReactComponent as FacebookIcon} from "../resources/facebook_icon.svg"
 //import {ReactComponent as InstagramIcon} from "../resources/instagram_icon.svg"
 import {getImageURL} from "../services/images";
+import MementoListMobile from "./MementoListMobile"
 const ReactMarkdown = require('react-markdown')
 
 
@@ -90,6 +92,9 @@ export const PostViewMobile = (props) => {
             }
             </h1>
           </div>
+          <button className="mobileButtonContainer">
+            <ClearIcon className="mobileIcon" onClick={() => props.history.push("/")}/>
+          </button>
 
         </div>
         <div className="postImageContainer">
@@ -124,7 +129,7 @@ export const PostViewMobile = (props) => {
                   <div className="postButtonsContainerInnerMobile">
                     <button className="rippleButton fillButton bigButton"onClick={() => setDeleteState(true)}>{props.settings.strings["delete_post"]}</button>
                     <div className="divider"/>
-                    <button className="rippleButton fillButton bigButton" onClick={() => editPostClick(post.id)}>{props.settings.strings["change_image"]}</button>
+                    <button className="rippleButton fillButton bigButton" onClick={() => editPostClick(post.id)}>{props.settings.strings["change_information"]}</button>
                     <div className="divider"/>
                   </div>
                   {!post.waiting_approval?
@@ -144,7 +149,7 @@ export const PostViewMobile = (props) => {
                   <div className="postButtonsContainerInnerMobile">
                     <button className="rippleButton fillButton bigButton"onClick={() => setDeleteState(true)}>{props.settings.strings["delete_post"]}</button>
                     <div className="divider"/>
-                    <button className="rippleButton fillButton bigButton" onClick={() => editPostClick(post.id)}>{props.settings.strings["change_image"]}</button>
+                    <button className="rippleButton fillButton bigButton" onClick={() => editPostClick(post.id)}>{props.settings.strings["change_information"]}</button>
                     <div className="divider"/>
                   </div>
                   :
@@ -165,7 +170,7 @@ export const PostViewMobile = (props) => {
             }
         </div>
         <div className="storyContainer">
-          <MementoList posts={post} history={props.history}/> 
+          <MementoListMobile posts={post} history={props.history}/> 
         </div>
       </div>
 )

--- a/src/componentsMobile/ProjectInfoMobile.js
+++ b/src/componentsMobile/ProjectInfoMobile.js
@@ -1,13 +1,13 @@
-import React, {useEffect, useState} from "react"
-import {connect} from "react-redux"
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
 
-import {notify} from "../reducers/notificationReducer"
+import { notify } from "../reducers/notificationReducer"
 
-import "../styles/projectInfo.css"
 import "../styles/containers.css"
+import "../styles/projectInfo.css"
 
-import {ReactComponent as ReturnIcon} from "../resources/arrow_back.svg"
-import {getImageURL} from "../services/images";
+import { ReactComponent as ReturnIcon } from "../resources/arrow_back.svg"
+import { getImageURL } from "../services/images"
 const ReactMarkdown = require('react-markdown')
 
 export const ProjectInfoMobile = (props) => {

--- a/src/componentsMobile/ProjectManagementMobile.js
+++ b/src/componentsMobile/ProjectManagementMobile.js
@@ -1,17 +1,18 @@
-import React, {useEffect, useState} from "react"
-import {connect} from "react-redux"
-import {notify} from "../reducers/notificationReducer"
+import { useEffect, useState } from "react"
 import { CSVLink } from "react-csv"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
 
-import "../styles/postView.css"
+import { ReactComponent as ReturnIcon } from "../resources/arrow_back.svg"
 import "../styles/accountInfo.css"
-import {ReactComponent as ReturnIcon} from "../resources/arrow_back.svg"
+import "../styles/postView.css"
 
 export const ProjectManagementMobile = (props) => {
   //declare some variables
   const [project, setProject] = useState(props.projects.active)
   const [posts, setPosts] = useState(props.posts)
   const [csvData, setCsvData] = useState([])
+  const [moderatorList, setModeratorList] = useState([])
 
   //in useEffect, check if we have some active project, check its posts and update data for csv download
   useEffect(() => {
@@ -24,17 +25,32 @@ export const ProjectManagementMobile = (props) => {
     }
     //if there is no csv data, generate it
     if(csvData.length <= 1){
-      const postsData = [["Project", "Project moderator", "Site ID", "Site title", "Site creator", "Last modifier", "Memories", "Location latitude", "Location longitude", "Abstract"]]
+      const postsData = [["Project", "Project moderators", "Site ID", "Site title", "Site creator", "Last modifier", "Memories", "Location latitude", "Location longitude", "Abstract"]]
       posts.map((post) => postsData.push([project.title, project.moderators, post.id, post.title, post.creator, post.modifier, post.muistoja, post.location.lat, post.location.lng, post.abstract]))
       //update data to csvData variable
       setCsvData(postsData)
     }
-  }, [props, project.title, posts, csvData.length, project.moderators])
+    //initialize new list of moderators with ',' between items for display purposes
+    if (moderatorList.length <= 1) {
+      const modlist = []
+      project.moderators.map((value) => modlist.push(value + ", "))
+      //remove ',' from last item and add it back
+      let lastItem = modlist.pop().slice(0, -2)
+      modlist.push(lastItem)
+      setModeratorList(modlist)
+    }
+  }, [props, project.title, posts, csvData.length, project.moderators, moderatorList.length])
 
   const changeProjectInfo = (event) => {
     //go to project settings page
     event.preventDefault()
     props.history.push("/project-settings")
+  }
+
+  const addModeratorClick = (event) => {
+    //go to moderator settings page
+    event.preventDefault()
+    props.history.push("/project-moderators")
   }
 
   if(props.user && project.moderators.find(user => user === props.user.username)){
@@ -63,7 +79,7 @@ export const ProjectManagementMobile = (props) => {
                 </tr>
                 <tr className="userInfoRows">
                   <th className="userInfoValues">{props.settings.strings["project_mod"]}</th>
-                  <th className="userInfoValues">{project.moderators !== null ? project.moderators : "-"}</th>
+                  <th className="userInfoValues">{project.moderators !== null ? moderatorList : "-"}</th>
                 </tr>
                 <tr className="userInfoRows">
                   <th className="userInfoValues">{props.settings.strings["project_sites"]}</th>
@@ -71,7 +87,7 @@ export const ProjectManagementMobile = (props) => {
                 </tr>
                 <tr className="userInfoRows">
                   <th className="userInfoValues">{props.settings.strings["abstract"]}</th>
-                  <th className="userInfoValues">{project.description !== null ? (project.description.length > 70 ? project.description.slice(0, 70) + '...': project.description) : "-"}</th>
+                  <th className="userInfoValues">{project.description !== null ? (project.description.length > 50 ? project.description.slice(0, 50) + '...': project.description) : "-"}</th>
                 </tr>
                 <tr className="userInfoRows">
                   <th className="userInfoValues">{props.settings.strings["description"]}</th>
@@ -82,6 +98,7 @@ export const ProjectManagementMobile = (props) => {
           </div>
           <div className="userInfoButtonsContainerMobile">
           <button className="rippleButton" onClick={changeProjectInfo}>{props.settings.strings["change_information"]}</button>
+          <button className="rippleButton" onClick={addModeratorClick}>{props.settings.strings["add_new_moderator"]}</button>
           <CSVLink
                 data={csvData}
                 filename={project.id + '-sites.csv'}
@@ -103,7 +120,7 @@ export const ProjectManagementMobile = (props) => {
           </button>
           </div>
           <div className="userInformationTitleMobile">
-            <h1 className="titleTextMobile" onClick={() => props.history.push("/login")}>{props.settings.strings["login_or_register"]}</h1>
+            <h1 className="titleTextMobile">{props.settings.strings["not_moderator"]}</h1>
           </div>
         </div>
       </div>

--- a/src/componentsMobile/ProjectModeratorsMobile.js
+++ b/src/componentsMobile/ProjectModeratorsMobile.js
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
+import { addNewModerator } from "../reducers/projectReducer"
+import { ReactComponent as ClearIcon } from "../resources/clear.svg"
+import "../styles/userSettings.css"
+
+export const ProjectModeratorsMobile = (props) => {
+  const [project, setProject] = useState(props.projects.active)
+
+  //in useEffect, check if we have some active project
+  useEffect(() => {
+    if(!project.title){
+      setProject(props.projects.active)
+    }
+  }, [props, project.title])
+
+  const modifyConfirmClick = async (event) => {
+    //replace hashtags with %23, because url can't read hashtags in usernames correctly
+    let new_mod = event.target.new_moderator.value.replace(/#/g, "%23")
+    event.preventDefault()
+    //if inputted username isn't empty, try to add it as a new moderator
+    if(event.target.new_moderator.value !== "") {
+      props.addNewModerator(project.id, new_mod)
+      props.notify(props.settings.strings["project_modify_ok"], false, 8)
+    }
+    //if it is empty, notificate user that no new changes to make
+    else {
+      props.notify(props.settings.strings["no_new_changes"], false, 5)
+    }
+    props.history.push("/project-management")
+  }
+
+  if(props.user && project.moderators.find(user => user === props.user.username)){
+    return(
+      <div className="loginContainerMobile">
+        <div className="titleContainerMobile">
+          <h1 className="titleTextMobile">{props.settings.strings["add_new_moderator"]}</h1>
+        </div>
+        <form className="userSettingsFormMobile" onSubmit={modifyConfirmClick}>
+          <div>
+            <div className="infoTextContainer">
+              <p className="normalText">{props.settings.strings["new_moderator_instructions"]}</p>
+            </div>
+            <div className="inputContainer">
+              <input name="new_moderator" className="input" placeholder={props.settings.strings["new_mod_placeholder"]} maxLength="150"/>
+              <div className="inputFocusLine"/>
+            </div>
+          </div>
+
+          <div className="dualButtonContainer">
+            <button type="submit" className="positiveButton rippleButton fillButton">{props.settings.strings["confirm"]}</button>
+            <button type="button" className="negativeButton rippleButton fillButton" onClick={() => props.history.push("/project-management")}>{props.settings.strings["cancel"]}</button>
+          </div>
+        </form>
+      </div>
+    )
+  }
+  else {
+    return (
+      <div className="userSettingsContainerMobile">
+        <div className="postTitleContainer">
+          <h1 className="titleText centerAlignWithPadding">{props.settings.strings["not_moderator"]}</h1>
+          <ClearIcon className="clearIcon" onClick={() => props.history.push("/")}/>
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    projects: state.projects,
+    settings: state.settings,
+    user: state.user
+  }
+}
+
+const mapDispatchToProps = {
+  notify, 
+  addNewModerator
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ProjectModeratorsMobile)

--- a/src/componentsMobile/ProjectSettingsMobile.js
+++ b/src/componentsMobile/ProjectSettingsMobile.js
@@ -1,9 +1,9 @@
-import React, {useEffect, useState} from "react"
-import {connect} from "react-redux"
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
 import { changeProjectSettings } from "../reducers/projectReducer"
-import {notify} from "../reducers/notificationReducer"
+import { ReactComponent as ClearIcon } from "../resources/clear.svg"
 import "../styles/userSettings.css"
-import {ReactComponent as ClearIcon} from "../resources/clear.svg"
 
 export const ProjectSettings = (props) => {
   const [project, setProject] = useState(props.projects.active)
@@ -104,7 +104,7 @@ export const ProjectSettings = (props) => {
   }
   else {
     return (
-      <div className="userInformationContainer centerAlignWithPadding">
+      <div className="userInformationContainer centerAlignWithPaddingContainer">
         <div className="postTitleContainer">
           <h1 className="titleText centerAlignWithPadding">{props.settings.strings["not_moderator"]}</h1>
           <ClearIcon className="clearIcon" onClick={() => props.history.push("/")}/>

--- a/src/componentsMobile/ProjectStatsMobile.js
+++ b/src/componentsMobile/ProjectStatsMobile.js
@@ -1,12 +1,11 @@
-import React from "react"
 //import React, {useState} from "react"
-import {connect} from "react-redux"
+import { connect } from "react-redux"
 
-import {notify} from "../reducers/notificationReducer"
+import { notify } from "../reducers/notificationReducer"
 
+import { ReactComponent as ReturnIcon } from "../resources/arrow_back.svg"
 import "../styles/inputs.css"
 import "../styles/projectStatistics.css"
-import {ReactComponent as ReturnIcon} from "../resources/arrow_back.svg"
 
 
 

--- a/src/componentsMobile/SetUserNameMobile.js
+++ b/src/componentsMobile/SetUserNameMobile.js
@@ -1,8 +1,8 @@
-import React, {useState} from "react"
-import {connect} from "react-redux"
-import {changeUsernameReducer} from "../reducers/loginReducer"
-import {initPosts} from "../reducers/postReducer"
-import {notify} from "../reducers/notificationReducer"
+import { useState } from "react"
+import { connect } from "react-redux"
+import { changeUsernameReducer } from "../reducers/loginReducer"
+import { notify } from "../reducers/notificationReducer"
+import { initPosts } from "../reducers/postReducer"
 import "../styles/loginForm.css"
 
 

--- a/src/componentsMobile/SiteImageUploadMobile.js
+++ b/src/componentsMobile/SiteImageUploadMobile.js
@@ -1,9 +1,9 @@
 //by Niklas Impiö
-import React, {useState, useEffect} from "react"
-import {connect} from "react-redux"
+import { useEffect, useState } from "react"
+import { connect } from "react-redux"
 
-import {notify} from "../reducers/notificationReducer"
-import {setTempSite} from "../reducers/tempSiteReducer"
+import { notify } from "../reducers/notificationReducer"
+import { setTempSite } from "../reducers/tempSiteReducer"
 
 import "../styles/imageUpload.css"
 

--- a/src/componentsMobile/UnverifiedPostsMobile.js
+++ b/src/componentsMobile/UnverifiedPostsMobile.js
@@ -1,15 +1,14 @@
 // By: Niklas Impiö
-import React from "react"
-import {connect} from "react-redux"
-import {notify} from "../reducers/notificationReducer"
+import { connect } from "react-redux"
+import { notify } from "../reducers/notificationReducer"
 
-import "../styles/myPosts.css"
 import "../styles/buttons.css"
+import "../styles/myPosts.css"
 import "../styles/texts.css"
 
 
-import {ReactComponent as ReturnIcon} from "../resources/arrow_back.svg"
-import {getImageURL} from "../services/images";
+import { ReactComponent as ReturnIcon } from "../resources/arrow_back.svg"
+import { getImageURL } from "../services/images"
 
 
 

--- a/src/componentsMobile/UserSettingsMobile.js
+++ b/src/componentsMobile/UserSettingsMobile.js
@@ -1,10 +1,10 @@
-import React, {useState} from "react"
-import {connect} from "react-redux"
+import { useState } from "react"
+import { connect } from "react-redux"
 import { changeUserSettings } from "../reducers/loginReducer"
-import {notify} from "../reducers/notificationReducer"
+import { notify } from "../reducers/notificationReducer"
 import "../styles/userSettings.css"
 
-import {ReactComponent as ReturnIcon} from "../resources/arrow_back.svg"
+import { ReactComponent as ReturnIcon } from "../resources/arrow_back.svg"
 
 export const UserSettingsMobile = (props) => {
   /*

--- a/src/reducers/postReducer.js
+++ b/src/reducers/postReducer.js
@@ -9,6 +9,7 @@ const EDIT_POST = "EDIT_POST"
 const CREATE_POST = "CREATE_POST"
 const CREATE_SITE = "CREATE_SITE"
 const DELETE_POST = "DELETE_POST"
+const DELETE_MEMORY = "DELETE_MEMORY"
 
 const postReducer = (state = [], action) => {
     // dispatch actions defined here.
@@ -24,6 +25,8 @@ const postReducer = (state = [], action) => {
         case CREATE_SITE:
             return state.concat(action.data)
         case DELETE_POST:
+            return state.filter(item => item.id !== action.data)
+        case DELETE_MEMORY:
             return state.filter(item => item.id !== action.data)
         default:
             return state
@@ -87,6 +90,25 @@ export const deletePost = (id) => {
             log(exeption)
         }
     }
+}
+
+export const deleteMemory = (site_id, memento_id) => {
+  log("deleting memory " + memento_id.toString())
+  return async dispatch => {
+      try {
+          const response = await postService.deleteMemory(getActiveProject(), site_id, memento_id)
+          log(response)
+          if (response.status === 200) {
+              dispatch({
+                  type: DELETE_MEMORY,
+                  data: memento_id
+              })
+          }
+
+      } catch (exeption) {
+          log(exeption)
+      }
+  }
 }
 
 export const toggleVerify = (site) => {
@@ -153,6 +175,47 @@ export const  changeSitePicture = (site, image) => {
             log(exeption)
         }
     }
+}
+
+//function for changing site title
+export const  ChangeSiteTitle = (site, title) => {
+  return async dispatch => {
+      try {
+          const response = await postService.ChangeSiteTitle(
+              getActiveProject(),
+              site.id,
+              title,
+              site.abstract,
+              site.description
+          )
+          dispatch({
+              type: EDIT_POST,
+              data: response.data
+          })
+      } catch (exeption) {
+          log(exeption)
+      }
+  }
+}
+
+//function for changing site location
+export const  ChangeSiteLocation = (site, latitude, longitude) => {
+  return async dispatch => {
+      try {
+          const response = await postService.ChangeSiteLocation(
+              getActiveProject(),
+              site.id,
+              latitude,
+              longitude
+          )
+          dispatch({
+              type: EDIT_POST,
+              data: response.data
+          })
+      } catch (exeption) {
+          log(exeption)
+      }
+  }
 }
 
 export default postReducer

--- a/src/reducers/projectReducer.js
+++ b/src/reducers/projectReducer.js
@@ -83,7 +83,7 @@ export const createProject = (project_id, object) => {
           const projects = (await projectService.getAllProjects())
           projects.push(object)
           console.log("New projects: ", projects)
-          const newProject = await projectService.createNewProject(projects)
+          await projectService.createNewProject(projects)
           let activeProject = null
           if (project_id) {
               activeProject = projects.find(project => project.id.toString() === project_id)
@@ -108,8 +108,9 @@ export const createProject = (project_id, object) => {
 export const changeProjectSettings = (modifiedproject) => {
   return async dispatch => {
       try{
-          const projectSettings = await projectService.changeSettings(
-            modifiedproject.id, modifiedproject.lang, modifiedproject.name, modifiedproject.abstract, modifiedproject.description)
+          //get language from current project settings
+          const oldProject = await projectService.getSingleProject(modifiedproject.id)
+          await projectService.changeSettings(modifiedproject.id, oldProject.info.lang, modifiedproject.name, modifiedproject.abstract, modifiedproject.description)
           const projects = (await projectService.getAllProjects())
           let activeProject = null
           if (modifiedproject.id) {
@@ -132,15 +133,10 @@ export const changeProjectSettings = (modifiedproject) => {
   }
 }
 
-export const addNewModerator = (project_id, moderators) => {
+export const addNewModerator = (project_id, new_moderator) => {
   return async dispatch => {
       try{
-        //const singleProject = await projectService.getSingleProject(project_id)
-        //console.log("Single project1: ", singleProject)
-        //singleProject.admins = moderators
-        //console.log("Single project2: ", singleProject)
-        const projectSettings = await projectService.addNewMod(
-          project_id, moderators)
+        await projectService.addNewMod(project_id, new_moderator)
         const projects = (await projectService.getAllProjects())
         let activeProject = null
         if (project_id) {

--- a/src/services/paths.ts
+++ b/src/services/paths.ts
@@ -7,6 +7,7 @@ const MEMORIES = 'memories'
 const COMMENTS = 'comments'
 const USER = 'me'
 const USERNAME = 'username'
+const NEW_ADMIN = 'admins?username='
 export const EMAIL_ONLY_LOGIN = '/auth/email'
 export const EMAIL_ONLY_EXCHANGE = '/auth/email/exchange'
 export const VERIFY_USER_EXCHANGE = '/auth/confirm'
@@ -87,6 +88,15 @@ const project = async <T>(
     PROJECTS, project
 ]))
 
+const projectAdmins = async <T>(
+  pathConsumer: ((url: string) => Promise<T>),
+  project: string, 
+  admin: string
+) => await pathConsumer(toUrl([
+  PROJECTS, project,
+  NEW_ADMIN
+]) + admin)
+
 const login = async <T>(pathConsumer: ((url: string) => Promise<T>)) => await pathConsumer(toUrl([ LOGIN]))
 const register = async <T>(pathConsumer: ((url: string) => Promise<T>)) => await pathConsumer(toUrl([ REGISTER]))
 const user = async <T>(pathConsumer: ((url: string) => Promise<T>)) => await pathConsumer(toUrl([ USER]))
@@ -95,7 +105,7 @@ export {
     comments, comment,
     memories, memory,
     sites, site,
-    projects, project,
+    projects, project, projectAdmins,
     login, register,
     user, username
 }

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -1,7 +1,7 @@
 import axios from "axios"
 import {convNOM, convNOS, convONM, convONS, Image, OldMemory, OldMemoryOutbound, OldSite, SearchParams} from "./models";
 import {log} from "./settings";
-import {memories, memory as memoryPath, project, site as sitePath, sites} from "./paths";
+import {memories, memory as memoryPath, site as sitePath, sites} from "./paths";
 
 export const getSites = async (project: string, params?: SearchParams): Promise<OldSite[]> => {
     log('doing search')
@@ -87,4 +87,27 @@ export const ChangeSitePicture = async (project: string, site: string, image: Im
     async (url) => await axios.patch(url, {image:image, _method: 'patch'}),
     project,
     site
+)
+
+//async function for changing site title with patch request
+export const ChangeSiteTitle = async (project: string, site: string, title: string, abstract: string, description: string) => await sitePath(
+  async (url) => await axios.patch(url, {
+    "info": {
+      "lang": "en", 
+      "name": title, 
+      "abstract": abstract, 
+      "description": description}}),
+  project,
+  site
+)
+
+//async function for changing site location  with patch request
+export const ChangeSiteLocation = async (project: string, site: string, latitude: number, longitude: number) => await sitePath(
+  async (url) => await axios.patch(url, {
+    "location": {
+      "lon": longitude, 
+      "lat": latitude}
+    }),
+  project,
+  site
 )

--- a/src/services/projects.ts
+++ b/src/services/projects.ts
@@ -1,5 +1,5 @@
 import axios from "axios"
-import {projects, project as projectPath} from "./paths";
+import {projects, project as projectPath, projectAdmins as projectAdminPath} from "./paths";
 import {convNOP, OldProject} from "./models";
 
 
@@ -24,13 +24,8 @@ export async function changeSettings(
       "lang":lang,
       "name":name,
       "abstract":abstract,
-      "description":description}}), project_id))
-}
-
-//async function for creating a new project
-export async function createNewProject (
-  project: object): Promise<OldProject[]>  {
-    return [... (await projects(async (url) => await axios.patch(url, {project}))).data.items]
+      "description":description}
+    }), project_id))
 }
 
 //async function for getting a single project
@@ -39,13 +34,16 @@ export async function getSingleProject (
     return (await projectPath(async (url) => await axios.get(url), project_id)).data
 }
 
+//async function for creating a new project
+export async function createNewProject (
+  project: object): Promise<OldProject[]>  {
+    return [... (await projects(async (url) => await axios.patch(url, {project}))).data.items]
+}
+
 //async function for adding new project moderator with patch request
 export async function addNewMod (
   project_id: string, 
-  mods: string[]): Promise<OldProject[]>  {
-    console.log("new admins: ", mods)
-    return (await projectPath(async (url) => await axios.patch(url, {
-      "id":project_id,
-      "admins": mods
-      }), project_id))
+  mod: string): Promise<OldProject[]>  {
+    return (await projectAdminPath(async (url) => await axios.post(url, {
+      }), project_id, mod))
 }

--- a/src/strings/stringStorage.json
+++ b/src/strings/stringStorage.json
@@ -2,7 +2,7 @@
   "supported_languages" : ["fi","en"],
   "language_strings":{
     "en":{
-      "look_at_mementos": "Browse mementos listed for this site",
+      "look_at_mementos": "Browse site information",
       "site_address": "https://www.muistotkartalla.fi",
       "app_name": "MUISTOT KARTALLA",
       "project_info": "Project Info",
@@ -92,6 +92,7 @@
       "verify": "Verify",
       "unverify": "Unverify",
       "confirm_delete": "Permanently Remove This Post",
+      "confirm_delete_memory": "Permanently Remove This Memory",
       "post": "Post",
       "delete_success": "Succesfully Deleted.",
 
@@ -111,9 +112,12 @@
       "tos_title": "Terms of Service",
       "tos_text": "Muistotkartalla.fi -service is a crowdsourced memento collection service for research projects. These terms outline how your information is used in the service.\nDATA PROCESSOR\n--------------\nThe service is provided by NeljäT Oy (2197596-6), who acts as a data processor and controller. Note that per project terms, your data may move, under your permission, beyond the control of this service.\nCOLLECTED DATA, DATA USE AND JUSTIFICATION\n------------------------------------------\nA cookie stored on your device is used to store your personal preferences regarding the service and to allow automatic login in case you have created an account\n\nPersonal information is stored on the server only if you create an account. For the account we require a minimum age of 13 years. Collected personal information is name, surname, email address, place of residence and year of birth in addition to the username of your choice.\n\nEmail address can be used for login purposes and to allow researchers of individual projects to send you messages, if you have given a per-project permission for it. Researchers will not be able to see your email address unless you respond to their message.\n\nFor implementing the service, we collect pictures and memories from the users for individual projects. The user grants permission to use the images, texts and recordings for research purposes in accordance with the per-project terms. The per-project terms, including what information you consent to provide the researchers, are agreed to separately for each project.\nDATA ERASURE\n------------\nYour username and the related information is held until:\n * Two years have passed since your most recent login AND\n * Every project that you have participated in, has finished.\nThe removal date of each project is shown on the project info page. When project is removed from the _muistotkartalla.fi_-service, they are removed permanently. Depending on per-project terms, data may be transferred outside the service for archive purposes.\n\nYou can at any point remove your information, your account and any uploaded memories from the service. Removing your account removes all uploaded data.\nCONTACT\n-------\nFor more information, contact gdpr@muistotkartalla.fi\n\nIndividual project contact information available from each projects *_Project Info_* page.\n",
 
-      "choose_location_first": "Choose your location on the map by clicking the left mouse button",
+      "choose_location_first": "Choose your location on the map by clicking the left mouse button", 
+      "choose_new_location": "Choose new location on the map",
+      "new_coordinates": "New coordinates:",
       "give_name_for_location": "Give a generally known name for the location",
-     "unfilled_fields": "Some of the Fields Are Still Empty. Fill Those and Try Again.",
+      "unfilled_fields": "Some of the Fields Are Still Empty. Fill Those and Try Again.",
+      "invalid_new_location": "New coordinates are invalid, try again.",
       "tos_unchecked": "You Need to Read and Accept the Terms of Service Before Creating an Account.",
       "password_reqs_not_met": "Password Needs to be at least 8 Characters Long.",
       "passwords_dont_match": "Password Fields Values Are not the Same.",
@@ -170,6 +174,10 @@
       "piiput": "Smokestack Memories",
       "parantolat": "Tuberculosis treatment facilities 1900-1970",
       "change_image": "Change Image",
+      "change_title": "Change Title",
+      "change_location": "Change Location",
+      "edit_post": "Change site information",
+      "no_permission": "You don't have permission for this page",
       "imageless_posts": "Imageless Posts",
       "change_username": "Change Username",
       "set_username": "Set a Username",
@@ -180,7 +188,7 @@
       "country_name": "Country"
     },
     "fi":{
-      "look_at_mementos": "Katsele tälle kohteelle syötettyjä muistoja",
+      "look_at_mementos": "Katsele kohteen tietoja",
       "new_memento": "Syötetään uusi muisto kohteelle ",
       "site_address": "https://www.muistotkartalla.fi",
       "app_name": "MUISTOT KARTALLA",
@@ -265,6 +273,7 @@
 
       "delete_post": "Poista",
       "confirm_delete": "Poista tämä kohde lopullisesti",
+      "confirm_delete_memory": "Poista tämä muisto lopullisesti",
       "post": "Kohde",
       "delete_success": "Poistettu.",
 
@@ -286,6 +295,7 @@
       "tos_text": "Muistotkartalla.fi -palvelu on arkeologisen muistojen ja niihin liittyvien kuvien keräyspalvelu tutkimusprojektien käyttöön. Nämä käyttöehdot kertovat, miten tietojasi käytetään palvelussa.\nREKISTERINPITÄJÄ JA TIETOJENKÄSITTELIJÄ\n---------------------------------------\nMuistotkartalla.fi palvelusta vastaa NeljäT Oy (2197596-6), joka toimii palvelussa rekisterinpitäjänä ja tietojenkäsittelijänä.\nKERÄTYT TIEDOT, NIIDEN KÄYTTÖ JA TIEDONKERUUN PERUSTEET\n------------------------------------------------------------------\nOmalle laitteellesi tallentuva eväste sisältää tietoa sivustolla käyttämistäsi asetuksista ja mahdollistaa sen, että valitsemasi asetukset ovat käytössä myös palatessasi sivustolle myöhemmin sekä sen, että pysyt kirjautuneena sisään palveluun, mikäli sinulla on käyttäjätunnus.\n\nSinusta kerätään palvelimellemme henkilökohtaisia tietoja vain, mikäli kirjaudut palveluun käyttäjäksi. Palveluun kirjautuvilta käyttäjiltä keräämme nimen, sukunimen, sähköpostiosoitteen, asuinpaikan ja syntymävuoden käyttäjän valitseman käyttäjätunnuksen lisäksi. Edellytämme palvelun käyttäjiltä 13 vuoden ikää.\n\nSähköpostiosoitetta voidaan käyttää kirjautumisten varmentamiseksi ja jotta tutkimusprojektien tutkijat voivat ottaa sinuun yhteyttä palvelun kautta, mikäli annat siihen projektikohtaisen luvan. Tutkijat eivät kuitenkaan näe sähköpostiosoitettasi, ellet vastaa heidän viestiinsä.\n\nPalvelun toteuttamiseksi keräämme käyttäjiltä kuvia ja muistoja kunkin tutkimusprojektin kohteista. Käyttäjä antaa luvan palveluun syötettyjen kuvien, tekstien ja nauhoitteiden käyttöön tutkimustarkoituksiin projektikohtaisten ehtojen mukaisesti. Projektikohtaiset ehdot, ja kunkin muiston lataajasta projektille toimitettavat tiedot hyväksytään aina kunkin projektin kohdalla erikseen.\nTIETOJEN POISTAMINEN\n--------------------\nKäyttäjätunnustasi sekä siihen liittyviä tietoja säilytetään kunnes\n * Viimeisestä kirjautumisestasi on kulunut kaksi vuotta JA\n * jokainen tutkimusprojekti jonka tiedonkeruuseen olet osallistunut, on päättynyt.\n\nKunkin tutkimusprojektin voimassaoloaika näkyy projektin *_Tietoa projektista_*-sivulta. Projektin päättyessä siihen ladatut muistotiedot tuhoutuvat pysyvästi _muistotkartalla.fi-palvelusta_. Projektikohtaisten ehtojen mukaisesti muistotiedot saatetaan siirtää arkistoitavaksi johonkin muuhun arkistoon tutkimusta varten.\n\nVoit missä vaiheessa vain poistaa omat tietosi, käyttäjätunnuksesi sekä lataamiasi muistoja palvelusta. Käyttäjätunnuksen poistaminen poistaa myös kaikki lataamasi muistot.\nYHTEYSTIEDOT\n------------\nLisätietoja ja kysymykset muistotkartalla.fi -palvelusta sähköpostitse osoitteeseen gdpr@muistotkartalla.fi\nYksittäisten tutkimusprojektien yhteystiedot ja käyttöehdot löytyvät kunkin projektin *_Tietoa projektista_*-sivulta.\n",
 
       "unfilled_fields": "Täytä loputkin kentät.",
+      "invalid_new_location": "Syötetyt koordinaatit ovat virheellisiä, kokeile uudestaan.",
       "tos_unchecked": "Sinun on hyväksyttävä käyttöehdot edetäksesi",
       "password_reqs_not_met": "Salasanan oltava vähintään 8 merkkiä",
       "passwords_dont_match": "Salasanat eivät täsmää.",
@@ -315,6 +325,8 @@
       "go_to_signup_instead": "Luo uusi tili",
 
       "choose_location_first": "Valitse kohteesi sijainti kartalta hiiren vasenta nappia klikkaamalla",
+      "choose_new_location": "Valitse uusi sijainti kartalta",
+      "new_coordinates": "Uudet koordinaatit:",
       "give_name_for_location": "Anna kohteellesi yleisesti tunnettu nimi",
 
       "reports": "Raportit",
@@ -346,6 +358,10 @@
       "piiput": "Piippumuistoja",
       "parantolat": "Tuberkuloosiparantolat 1900-1970",
       "change_image": "Vaihda kuva",
+      "change_title": "Vaihda otsikko",
+      "change_location": "Vaihda lokaatio",
+      "edit_post": "Vaihda kohteen tietoja",
+      "no_permission": "Sinulla ei ole vaadittavia oikeuksia",
       "imageless_posts": "Kuvattomat kohteet",
       "change_username": "Vaihda Käyttäjänimeä",
       "set_username": "Aseta Käyttäjänimi",

--- a/src/styles/dropDownSelect.css
+++ b/src/styles/dropDownSelect.css
@@ -23,7 +23,7 @@
   justify-content: space-between;
   height: 4em;
   width: 16em;
-  margin: 0px 10px;
+  
 }
 
 .dropDownSelectCurrentItem:hover .dropDownIcon{

--- a/src/styles/languageDropDown.css
+++ b/src/styles/languageDropDown.css
@@ -1,7 +1,7 @@
 .languageDDContainer{
   background: var(--primary-color);
   justify-content: center;
-  width: 100%;
+  width: 97%;
   height: fit-content;
   height: -moz-fit-content;
   margin: auto;

--- a/src/styles/listView.css
+++ b/src/styles/listView.css
@@ -41,6 +41,14 @@
   height: 100%;
 }
 
+.centerAlignWithPaddingContainer{
+  margin: 0;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
 .postListSectionContainer{
   width: 35%;
   z-index: 4;

--- a/src/styles/loginForm.css
+++ b/src/styles/loginForm.css
@@ -79,7 +79,7 @@
   flex-direction: row;
 }
 
-.headerText{
+.headerText2{
   padding: 0px;
   color: var(--title-color);
   font-family: Lato,'Helvetica Neue',Arial,Helvetica,sans-serif;

--- a/src/styles/mapContainer.css
+++ b/src/styles/mapContainer.css
@@ -51,3 +51,24 @@
   top:1em;
   left: 4em;
 }
+
+.mapContainerSmall{
+  height: 500px;
+  width: 500px;
+  margin: auto;
+  margin-top: 20px;
+}
+
+.mapContainerSmallMobile{
+  height: 70%;
+  width: 80%;
+  margin: auto;
+}
+
+.smallMap{
+  cursor: all-scroll !important;
+  height: 100%;
+  width: 100%;
+  position: relative;
+  z-index: 1;
+}

--- a/src/styles/postList.css
+++ b/src/styles/postList.css
@@ -53,6 +53,17 @@
   border-radius: 10px;
   width: calc(100% - 50px)
 }
+.postListItemMobile{
+  cursor: pointer;
+  background: var(--primary-color);
+  display: grid;
+  margin: 5px 0;
+  padding: 10px;
+  border: 5px solid transparent;
+  border-radius: 10px;
+  width: calc(100% - 50px)
+}
+
 .postViewListItem{
   cursor: pointer;
   background: var(--primary-color);
@@ -79,6 +90,7 @@
   height: 100%;
   margin: auto 0.5em auto 0;
   align-content: center;
+  display: flex;
 }
 .postListReportFlags{
   width: 30%;
@@ -95,13 +107,12 @@
 
 
 .postListItemInfo {
-  width: 55%;
+  width: 100%;
   display: flex;
   flex-direction: column;
   text-align: start;
   cursor: pointer;
 }
-
 
 .postListTitle{
   font-family: Lato,'Helvetica Neue',Arial,Helvetica,sans-serif;
@@ -109,6 +120,17 @@
   font-weight: 700;
   font-size: 1.2em;
   margin: 0;
+
+}
+
+.postListTitleMobile{
+  font-family: Lato,'Helvetica Neue',Arial,Helvetica,sans-serif;
+  color: var(--primary-text-color);
+  font-weight: 700;
+  font-size: 1.2em;
+  margin: 0;
+  padding-left: 10px;
+  
 }
 
 .postListText{

--- a/src/styles/postView.css
+++ b/src/styles/postView.css
@@ -195,3 +195,13 @@
   max-width: 100%;
 }
 
+.memoryOwnerButtonsContainer{
+  padding: 5px 0 5px 0;
+  justify-content: space-around;
+  display: flex;
+  flex-direction: column;
+}
+
+.memoryOwnerButton{
+  margin: 5px;
+}


### PR DESCRIPTION
* Changes for fb and twitter share

* Updated dependecies & added marker cluster groups

Updated leaflet, react-leaflet, react and react-dom dependencies. Added markercluster groups. A few features like "Show on map" not working with new leaflet version.

* Fixed broken features & changed event handling on mapcontainer

Might still need some refining and further testing

* Fix for smoother zoom/move on mapcontainer

Added boolean to refresh map center only when necessary. Removed lagging.

* Little changes & code cleanup

* Added profile page for desktop version & Green marker for own posts

* Profile page implementation for mobile

* Improvements for mobile appearance

+ added green marker for own posts and changed colour of clusters to blue

* CSV export for project moderators + ...

Added new dependency "react-csv", fixed birthday display on account page, small improvements on appearance

* Fixed some react warnings

* Added csv export for mobile +

moved generating csv data inside useEffect to make it safer.

* GDPR compliance init

CookieConsent tests to feature, TODO: legal notice, styling, modelizing

* Project management page for desktop version...

+ small changes on account page

* Project management page for mobile

Removed unnecessary css

* Better visibility for light mode

* Added support for other project titles than "piiput" and "parantolat"...

+ commented out some console logs before master merge

* Merge branch Test2022 (#46) (#47)

* Changes for fb and twitter share

* Updated dependecies & added marker cluster groups

Updated leaflet, react-leaflet, react and react-dom dependencies. Added markercluster groups. A few features like "Show on map" not working with new leaflet version.

* Fixed broken features & changed event handling on mapcontainer

Might still need some refining and further testing

* Fix for smoother zoom/move on mapcontainer

Added boolean to refresh map center only when necessary. Removed lagging.

* Little changes & code cleanup

* Added profile page for desktop version & Green marker for own posts

* Profile page implementation for mobile

* Improvements for mobile appearance

+ added green marker for own posts and changed colour of clusters to blue

* CSV export for project moderators + ...

Added new dependency "react-csv", fixed birthday display on account page, small improvements on appearance

* Fixed some react warnings

* Added csv export for mobile +

moved generating csv data inside useEffect to make it safer.

* GDPR compliance init

CookieConsent tests to feature, TODO: legal notice, styling, modelizing

* Project management page for desktop version...

+ small changes on account page

* Project management page for mobile

Removed unnecessary css

* Better visibility for light mode

* Added support for other project titles than "piiput" and "parantolat"...

+ commented out some console logs before master merge

Co-authored-by: JooC <55877330+sussasminister@users.noreply.github.com>
Co-authored-by: Saku Antikainen <antikainensaku@gmail.com>

Co-authored-by: JooC <55877330+sussasminister@users.noreply.github.com>
Co-authored-by: Saku Antikainen <antikainensaku@gmail.com>

* Title support for other projects in mobile

+ better styling for cookies notification

* closes #42

* Initial implementation for changing project settings

+ replaced edit icon in account page with a regular button
+ display title instead of abstract in popups
+ small additions on styles and global strings

* Small improvement on changing project settings

* Same project settings improvements for mobile

* Login & about edits

* closes

* Fixes verifiedicon position in listview

* Fixes a few warnings and tweaks on verifiedicon position

* TabIndex

* Implemented a way to add new project moderators

+ Fixed some react warnings

* Added way to change site information

- Project admins and site owners can change site title, location and image
+ Added way to delete own memories

* Improved changing location of existing site

- Added small map to edit-location page. New location is now chosen by clicking on the map.
+ Removed some react warnings and added new global strings

* Refactoring components

clean unused imports, code & components

* Fixed css after component refactoring

* closes #38, closes #44

* Added own memory delete option for mobile

Co-authored-by: Lassi Tölli <lassi41@gmail.com>
Co-authored-by: Saku Antikainen <antikainensaku@gmail.com>
Co-authored-by: Lassi Tölli <55877751+latolli@users.noreply.github.com>
Co-authored-by: OMP404 <ol.paananen@hotmail.fi>