### PR TITLE
Fix adding new mementos/posts to sites/points of interest

### DIFF
--- a/src/services/models.ts
+++ b/src/services/models.ts
@@ -184,7 +184,7 @@ export function convONM(o: OldMemoryOutbound): Memory {
     return {
         title: o.title,
         story: o.story,
-        image: o.image.data.substr(0, 100).replace(/^data:image\/.+;base64,/, '') + o.image.data.substr(100)
+        image: o.image?.data?.substr(0, 100).replace(/^data:image\/.+;base64,/, '') + o.image?.data?.substr(100),
     } as Memory
 }
 


### PR DESCRIPTION
Adding new mementos was broken due to missing handling of `null` values when the post was missing an image. Just added conditionals `?`.
Tested and working locally now.