### PR TITLE
Make project info update immediately after editing without requiring page refresh

### DIFF
--- a/src/components/EditSiteTitle.js
+++ b/src/components/EditSiteTitle.js
@@ -1,47 +1,53 @@
 import { connect } from "react-redux"
 import { notify } from "../reducers/notificationReducer"
-
 import { ChangeSiteTitle } from "../reducers/postReducer"
 import "../styles/buttons.css"
 import "../styles/newPost.css"
-
-
 
 export const EditSiteTitle = (props) => {
   const post = props.posts.find(item => "" + item.id === props.match.params.id)
 
   const ConfirmNewTitle = (event) => {
     event.preventDefault()
-    if(event.target.newTitle.value === "")
-    {
+    if (event.target.newTitle.value === "") {
        props.notify(props.settings.strings["no_new_changes"], false, 5)
-    }
-    else {
+    } else {
       props.ChangeSiteTitle(post, event.target.newTitle.value)
       props.notify(props.settings.strings["site_modify_ok"], false, 5)
     }
     props.history.push(`/edit-post/${post.id}`)
   }
 
-  return(
+  return (
     <div className="userSettingsContainer centerAlignWithPadding">
-        <div className="titleContainer">
-          <h1 className="titleText">{props.settings.strings["change_title"]}</h1>
-        </div>
-        <form className="userSettingsForm" onSubmit={ConfirmNewTitle}>
-          <div className="inputContainer">
-            <input name="newTitle" className="input" placeholder={post.title !== null? post.title : "New Title"} maxLength="200"/>
-            <div className="inputFocusLine"/>
-          </div>
-
-          <div className="dualButtonContainer">
-            <button type="submit" className="positiveButton rippleButton fillButton">{props.settings.strings["confirm"]}</button>
-            <button type="button" className="negativeButton rippleButton fillButton" onClick={() => props.history.push(`/edit-post/${post.id}`)}>{props.settings.strings["cancel"]}</button>
-          </div>
-        </form>
+      <div className="titleContainer">
+        <h1 className="titleText">{props.settings.strings["change_title"]}</h1>
       </div>
+      <form className="userSettingsForm" onSubmit={ConfirmNewTitle}>
+        <div className="inputContainer">
+          <input
+            name="newTitle"
+            className="input"
+            placeholder={post.title || "New Title"}
+            maxLength="200"
+          />
+          <div className="inputFocusLine"/>
+        </div>
+        <div className="dualButtonContainer">
+          <button type="submit" className="positiveButton rippleButton fillButton">
+            {props.settings.strings["confirm"]}
+          </button>
+          <button 
+            type="button"
+            className="negativeButton rippleButton fillButton"
+            onClick={() => props.history.push(`/edit-post/${post.id}`)}
+          >
+            {props.settings.strings["cancel"]}
+          </button>
+        </div>
+      </form>
+    </div>
   )
-
 }
 
 const mapStateToProps = (state) => {
@@ -62,7 +68,6 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(EditSiteTitle)
-
 
 // EditSiteTitle: The component retrieves the post object to edit from the Redux store based on the id parameter passed in the URL.
 //  It then defines a function ConfirmNewTitle which will be called when the form is submitted. The function first checks if the new title is empty and, if so, displays a notification message

--- a/src/components/ProjectManagement.js
+++ b/src/components/ProjectManagement.js
@@ -16,13 +16,10 @@ export const ProjectManagement = (props) => {
 
   //in useEffect, check if we have some active project, check its posts and update data for csv download
   useEffect(() => {
-    if (!project.title) {
-      setProject(props.projects.active)
-    }
-    //check that we have all correct posts
-    if (props.posts !== posts) {
-      setPosts(props.posts)
-    }
+    // Update project and posts if they have changed
+    setProject(props.projects.active)
+    setPosts(props.posts)
+
     //if there is no csv data, generate it
     if (csvData.length <= 1) {
       const postsData = [[
@@ -53,15 +50,13 @@ export const ProjectManagement = (props) => {
       setCsvData(postsData)
     }
     //initialize new list of moderators with ',' between items for display purposes
-    if (moderatorList.length <= 1) {
-      const modlist = []
-      project.moderators.map((value) => modlist.push(value + ", "))
-      //remove ',' from last item and add it back
-      let lastItem = modlist.pop().slice(0, -2)
-      modlist.push(lastItem)
-      setModeratorList(modlist)
-    }
-  }, [props, project.title, posts, csvData.length, project.moderators, moderatorList.length])
+    const modlist = []
+    project.moderators.map((value) => modlist.push(value + ", "))
+    //remove ',' from last item and add it back
+    let lastItem = modlist.pop().slice(0, -2)
+    modlist.push(lastItem)
+    setModeratorList(modlist)
+  }, [props, project.title, project.moderators, posts, csvData])
 
   const closeClick = (event) => {
     //go back to the previous page

--- a/src/components/ProjectManagement.js
+++ b/src/components/ProjectManagement.js
@@ -111,7 +111,7 @@ export const ProjectManagement = (props) => {
                 </tr>
                 <tr className="userInfoRows">
                   <th className="userInfoValues">{props.settings.strings["project_sites"]}</th>
-                  <th className="userInfoValues">{posts.length > 1 ? posts.length : "-"}</th>
+                  <th className="userInfoValues">{posts.length}</th>
                 </tr>
                 <tr className="userInfoRows">
                   <th className="userInfoValues">{props.settings.strings["abstract"]}</th>

--- a/src/components/ProjectManagement.js
+++ b/src/components/ProjectManagement.js
@@ -16,17 +16,39 @@ export const ProjectManagement = (props) => {
 
   //in useEffect, check if we have some active project, check its posts and update data for csv download
   useEffect(() => {
-    if(!project.title){
+    if (!project.title) {
       setProject(props.projects.active)
     }
     //check that we have all correct posts
-    if(props.posts !== posts){
+    if (props.posts !== posts) {
       setPosts(props.posts)
     }
     //if there is no csv data, generate it
-    if(csvData.length <= 1){
-      const postsData = [["Project", "Project moderators", "Site ID", "Site title", "Site creator", "Last modifier", "Memories", "Location latitude", "Location longitude", "Abstract"]]
-      posts.map((post) => postsData.push([project.title, project.moderators, post.id, post.title, post.creator, post.modifier, post.muistoja, post.location.lat, post.location.lng, post.abstract]))
+    if (csvData.length <= 1) {
+      const postsData = [[
+        "Project",
+        "Project moderators",
+        "Site ID",
+        "Site title",
+        "Site creator",
+        "Last modifier",
+        "Memories",
+        "Location latitude",
+        "Location longitude",
+        "Abstract"
+      ]]
+      posts.map((post) => postsData.push([
+        project.title,
+        project.moderators,
+        post.id,
+        post.title,
+        post.creator,
+        post.modifier,
+        post.muistoja,
+        post.location.lat,
+        post.location.lng,
+        post.abstract,
+      ]))
       //update data to csvData variable
       setCsvData(postsData)
     }
@@ -59,11 +81,13 @@ export const ProjectManagement = (props) => {
     props.history.push("/project-moderators")
   }
 
-  if(props.user && project.moderators.find(user => user === props.user.username)){
+  if (props.user && project.moderators.find(user => user === props.user.username)) {
     return (
       <div className="userInformationContainer centerAlignWithPaddingContainer">
         <div className="postTitleContainer">
-          <h1 className="titleText centerAlignWithPadding">{props.settings.strings["project_management"]}</h1>
+          <h1 className="titleText centerAlignWithPadding">
+            {props.settings.strings["project_management"]}
+          </h1>
           <ClearIcon className="clearIcon" onClick={closeClick}/>
         </div>
         <div className="userInformation">
@@ -75,30 +99,50 @@ export const ProjectManagement = (props) => {
                 </tr>
                 <tr className="userInfoRows">
                   <th className="userInfoValues">{props.settings.strings["project_title"]}</th>
-                  <th className="userInfoValues">{project.title !== null ? project.title : "-"}</th>
+                  <th className="userInfoValues">
+                    {project.title !== null ? project.title : "-"}
+                  </th>
                 </tr>
                 <tr className="userInfoRows">
                   <th className="userInfoValues">{props.settings.strings["project_mod"]}</th>
-                  <th className="userInfoValues">{project.moderators !== null ? moderatorList : "-"}</th>
+                  <th className="userInfoValues">
+                    {project.moderators !== null ? moderatorList : "-"}
+                  </th>
                 </tr>
                 <tr className="userInfoRows">
                   <th className="userInfoValues">{props.settings.strings["project_sites"]}</th>
-                  <th className="userInfoValues">{posts.length  > 1 ? posts.length : "-"}</th>
+                  <th className="userInfoValues">{posts.length > 1 ? posts.length : "-"}</th>
                 </tr>
                 <tr className="userInfoRows">
                   <th className="userInfoValues">{props.settings.strings["abstract"]}</th>
-                  <th className="userInfoValues">{project.description !== null ? (project.description.length > 150 ? project.description.slice(0, 150) + '...': project.description) : "-"}</th>
+                  <th className="userInfoValues">
+                    {project.description !== null 
+                    ? (project.description.length > 150 
+                      ? project.description.slice(0, 150) + '...'
+                      : project.description) 
+                    : "-"}
+                  </th>
                 </tr>
                 <tr className="userInfoRows">
                   <th className="userInfoValues">{props.settings.strings["description"]}</th>
-                  <th className="userInfoValues">{project.contentDescription !== null ? (project.contentDescription.length > 150 ? project.contentDescription.slice(0, 150) + '...': project.contentDescription) : "-"}</th>
+                  <th className="userInfoValues">
+                    {project.contentDescription !== null
+                    ? (project.contentDescription.length > 150
+                      ? project.contentDescription.slice(0, 150) + '...'
+                      : project.contentDescription)
+                    : "-"}
+                  </th>
                 </tr>
                 </tbody>
             </table>
           </div>
           <div className="userInfoButtonsContainer">
-          <button className="rippleButton" onClick={changeProjectInfo}>{props.settings.strings["change_information"]}</button>
-          <button className="rippleButton" onClick={addModeratorClick}>{props.settings.strings["add_new_moderator"]}</button>
+          <button className="rippleButton" onClick={changeProjectInfo}>
+            {props.settings.strings["change_information"]}
+          </button>
+          <button className="rippleButton" onClick={addModeratorClick}>
+            {props.settings.strings["add_new_moderator"]}
+          </button>
           <CSVLink
                 data={csvData}
                 filename={project.id + '-sites.csv'}
@@ -109,19 +153,18 @@ export const ProjectManagement = (props) => {
           </div>
       </div>
     );
-  }
-  else {
+  } else {
     return (
       <div className="userInformationContainer centerAlignWithPadding">
         <div className="postTitleContainer">
-          <h1 className="titleText centerAlignWithPadding">{props.settings.strings["not_moderator"]}</h1>
+          <h1 className="titleText centerAlignWithPadding">
+            {props.settings.strings["not_moderator"]}
+          </h1>
           <ClearIcon className="clearIcon" onClick={closeClick}/>
         </div>
       </div>
     );
   }
-
-  
 };
 
 const mapStateToProps = (state) => {
@@ -143,8 +186,6 @@ const mapStateToProps = (state) => {
     mapStateToProps,
     mapDispatchToProps
   )(ProjectManagement)
-
-
 
 //   ProjectManagement: This component is used in ContentArea.js. The component returns a JSX template that displays information about the active project, such as its ID, title, moderators, number of sites, abstract,
 //  and description. It also displays buttons to download the project's CSV data, change project information, and add a new moderator if the current user is one of the moderators of the project. If the current user

--- a/src/components/ProjectSettings.js
+++ b/src/components/ProjectSettings.js
@@ -11,11 +11,11 @@ export const ProjectSettings = (props) => {
 
   //in useEffect, check if we have some active project
   useEffect(() => {
-    if(!project.title){
+    if (!project.title) {
       setProject(props.projects.active)
     }
     //check that we have all correct posts
-    if(props.posts !== posts){
+    if (props.posts !== posts) {
       setPosts(props.posts)
     }
   }, [props, project.title, posts])
@@ -26,20 +26,20 @@ export const ProjectSettings = (props) => {
     let new_title = project.title
     let new_abs = project.description
     let new_desc = project.contentDescription
-    if(event.target.project_title.value === "" && event.target.project_abstract.value === "" && event.target.project_description.value === "")
-    {
+    if (event.target.project_title.value === "" 
+      && event.target.project_abstract.value === "" 
+      && event.target.project_description.value === ""
+    ) {
       props.notify(props.settings.strings["no_new_changes"], false, 5)
-    }
-    else
-    {
+    } else {
       //replace old value with new value, if new value isn't empty
-      if(event.target.project_title.value !== "") {
+      if (event.target.project_title.value !== "") {
         new_title = event.target.project_title.value 
       }
-      if(event.target.project_abstract.value !== "") {
+      if (event.target.project_abstract.value !== "") {
         new_abs = event.target.project_abstract.value 
       }
-      if(event.target.project_description.value !== "") {
+      if (event.target.project_description.value !== "") {
         new_desc = event.target.project_description.value 
       }
       const modifiedProject = {
@@ -54,8 +54,8 @@ export const ProjectSettings = (props) => {
     }
   }
 
-  if(props.user && project.moderators.find(user => user === props.user.username)){
-    return(
+  if (props.user && project.moderators.find(user => user === props.user.username)) {
+    return (
       <div className="userSettingsContainer centerAlignWithPaddingContainer">
         <div className="titleContainer">
           <h1 className="titleText">{props.settings.strings["configure_project"]}</h1>
@@ -66,32 +66,67 @@ export const ProjectSettings = (props) => {
               <p className="normalText">{props.settings.strings["enter_values_to_change"]}</p>
             </div>
             <div className="inputContainer">
-              <input name="project_title" className="input" placeholder={project.title !== null ?  props.settings.strings["project_title"] + ": " + project.title : props.settings.strings["project_title"]} maxLength="150"/>
+              <input 
+                name="project_title"
+                className="input"
+                placeholder={
+                  project.title !== null
+                  ? props.settings.strings["project_title"] + ": " + project.title
+                  : props.settings.strings["project_title"]
+                }
+                maxLength="150"
+              />
               <div className="inputFocusLine"/>
             </div>
             <div className="inputContainer">
-              <input name="project_abstract" className="input" placeholder={project.description !== null ? props.settings.strings["abstract"] + ": " + project.description : props.settings.strings["abstract"]} maxLength="500"/>
+              <input 
+                name="project_abstract"
+                className="input"
+                placeholder={
+                  project.description !== null
+                  ? props.settings.strings["abstract"] + ": " + project.description
+                  : props.settings.strings["abstract"]
+                }
+                maxLength="500"
+              />
               <div className="inputFocusLine"/>
             </div>
             <div className="inputContainer">
-              <input name="project_description" className="input" placeholder={project.contentDescription !== null ? props.settings.strings["project_description"] + ": " + project.contentDescription : props.settings.strings["project_description"]} maxLength="1000"/>
+              <input
+                name="project_description"
+                className="input"
+                placeholder={
+                  project.contentDescription !== null
+                  ? props.settings.strings["project_description"] + ": " + project.contentDescription
+                  : props.settings.strings["project_description"]
+                }
+                maxLength="1000"
+              />
               <div className="inputFocusLine"/>
             </div>
           </div>
-
           <div className="dualButtonContainer">
-            <button type="submit" className="positiveButton rippleButton fillButton">{props.settings.strings["confirm"]}</button>
-            <button type="button" className="negativeButton rippleButton fillButton" onClick={() => props.history.push("/project-management")}>{props.settings.strings["cancel"]}</button>
+            <button type="submit" className="positiveButton rippleButton fillButton">
+              {props.settings.strings["confirm"]}
+            </button>
+            <button 
+              type="button"
+              className="negativeButton rippleButton fillButton"
+              onClick={() => props.history.push("/project-management")}
+            >
+              {props.settings.strings["cancel"]}
+            </button>
           </div>
         </form>
       </div>
     )
-  }
-  else {
+  } else {
     return (
       <div className="userInformationContainer centerAlignWithPaddingContainer">
         <div className="postTitleContainer">
-          <h1 className="titleText centerAlignWithPadding">{props.settings.strings["not_moderator"]}</h1>
+          <h1 className="titleText centerAlignWithPadding">
+            {props.settings.strings["not_moderator"]}
+          </h1>
           <ClearIcon className="clearIcon" onClick={() => props.history.push("/")}/>
         </div>
       </div>
@@ -117,8 +152,6 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(ProjectSettings)
-
-
 
 // ProjectSettings: This component is used in ContentArea.js. The modifyConfirmClick function is defined to modify the project settings when the user submits the form. The function first checks whether any changes
 //  have been made or not. If no changes have been made, the user is notified with a message. Otherwise, the function creates a modified project object and calls the changeProjectSettings function to update the project settings.

--- a/src/components/ProjectSettings.js
+++ b/src/components/ProjectSettings.js
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react"
 import { connect } from "react-redux"
 import { notify } from "../reducers/notificationReducer"
 import { changeProjectSettings } from "../reducers/projectReducer"
@@ -6,19 +5,7 @@ import { ReactComponent as ClearIcon } from "../resources/clear.svg"
 import "../styles/userSettings.css"
 
 export const ProjectSettings = (props) => {
-  const [project, setProject] = useState(props.projects.active)
-  const [posts, setPosts] = useState(props.posts)
-
-  //in useEffect, check if we have some active project
-  useEffect(() => {
-    if (!project.title) {
-      setProject(props.projects.active)
-    }
-    //check that we have all correct posts
-    if (props.posts !== posts) {
-      setPosts(props.posts)
-    }
-  }, [props, project.title, posts])
+  const project = props.projects.active
 
   const modifyConfirmClick = async (event) => {
     event.preventDefault()

--- a/src/components/SetUserName.js
+++ b/src/components/SetUserName.js
@@ -3,70 +3,79 @@ import { connect } from "react-redux"
 import { changeUsernameReducer } from "../reducers/loginReducer"
 import { notify } from "../reducers/notificationReducer"
 import { initPosts } from "../reducers/postReducer"
-
 import "../styles/loginForm.css"
-
 
 export const SetUserName = (props) => {
 
-    const [username, setUsername] = useState("")
+	const [username, setUsername] = useState("")
 
-    const cancelClick = (event) => {
-        event.preventDefault()
-        props.history.goBack()
-    }
+	const cancelClick = (event) => {
+		event.preventDefault()
+		props.history.goBack()
+	}
 
-    const UsernameChangeHandler = (event) => {
-        event.preventDefault()
-        setUsername(event.target.value)
-    }
-    const confirmUser = (event) => {
-        event.preventDefault()
-        props.changeUsernameReducer(username)
-        setUsername("")
-        props.history.push("/usersettings/")
-    }
-    return (
-        <div className="loginContainer centerAlignWithPaddingContainer">
-            <h1 className="headerText bottomPadding30">{props.settings.strings["set_username"]}</h1>
-     <form className="loginForm" onSubmit={confirmUser}>
-                <div className="inputContainer">
-                <input name="username" id="username" className="input" placeholder={props.settings.strings["user_name"]} maxLength="100" autoComplete="off" onChange={UsernameChangeHandler} value={username}/>
-                </div>
-                <div className="postFormButtonContainer">
-                    <button type="submit"
-                            className="positiveButton rippleButton fillButton">{props.settings.strings["continue"]}</button>
-                    <button className="negativeButton rippleButton fillButton"
-                            onClick={cancelClick}>{props.settings.strings["cancel"]}</button>
-                </div>
-            </form>
-        </div>
-    )
+	const UsernameChangeHandler = (event) => {
+		event.preventDefault()
+		setUsername(event.target.value)
+	}
+
+	const confirmUser = (event) => {
+		event.preventDefault()
+		props.changeUsernameReducer(username)
+		setUsername("")
+		props.history.push("/usersettings/")
+	}
+
+	return (
+		<div className="loginContainer centerAlignWithPaddingContainer">
+			<h1 className="headerText bottomPadding30">{props.settings.strings["set_username"]}</h1>
+			<form className="loginForm" onSubmit={confirmUser}>
+				<div className="inputContainer">
+					<input
+						name="username"
+						id="username"
+						className="input"
+						placeholder={props.settings.strings["user_name"]}
+						maxLength="100"
+						autoComplete="off"
+						onChange={UsernameChangeHandler}
+						value={username}
+					/>
+				</div>
+				<div className="postFormButtonContainer">
+					<button type="submit" className="positiveButton rippleButton fillButton">
+						{props.settings.strings["continue"]}
+					</button>
+					<button className="negativeButton rippleButton fillButton" onClick={cancelClick}>
+						{props.settings.strings["cancel"]}
+					</button>
+				</div>
+			</form>
+		</div>
+	)
 }
 
 const mapStateToProps = (state) => {
-    return {
-        //maps state to props, after this you can for example call props.notification
-        settings: state.settings,
-        projects: state.projects,
-        user: state.user
-    }
+	return {
+		//maps state to props, after this you can for example call props.notification
+		settings: state.settings,
+		projects: state.projects,
+		user: state.user
+	}
 }
 
 const mapDispatchToProps = {
-    //connect reducer functions/dispatchs to props
-    //notify (for example)
-    notify,
-    initPosts,
-    changeUsernameReducer
+	//connect reducer functions/dispatchs to props
+	//notify (for example)
+	notify,
+	initPosts,
+	changeUsernameReducer
 }
 
 export default connect(
-    mapStateToProps,
-    mapDispatchToProps
+	mapStateToProps,
+	mapDispatchToProps
 )(SetUserName)
-
-
 
 // SetUserName: This component is used in ContentArea.js. The component uses the useState hook to manage the state of the input field for the username. When the form is submitted, it calls confirmUser function,
 //  which dispatches an action to update the username in the store using changeUsernameReducer from the loginReducer.

--- a/src/components/UserSettings.js
+++ b/src/components/UserSettings.js
@@ -3,6 +3,10 @@ import { changeUserSettings, logout } from "../reducers/loginReducer"
 import { notify } from "../reducers/notificationReducer"
 import "../styles/userSettings.css"
 
+/* 
+TODO: FIX THIS IMPLEMENTATION WHEN THE REDUCER IS FIXED.
+GITHUB ISSUE #139
+*/
 export const UserSettings = (props) => {
   /*
   Component for configuring user settings. Change password etc.

--- a/src/components/UserSettings.js
+++ b/src/components/UserSettings.js
@@ -60,34 +60,23 @@ export const UserSettings = (props) => {
     }
   */
   const modifyConfirmClick = async (event) => {
-    //console.log("attempting profile modification")
+
     event.preventDefault()
-    if(event.target.city.value === "" && event.target.dob.value === "")
-    {
+    if (event.target.city.value === "" && event.target.dob.value === "") {
       props.notify(props.settings.strings["no_new_changes"], false, 5)
-    }
-    else
-    {
-
-
+    } else {
       const modifiedUser = {
-
         "new_country": event.target.country.value,
         "new_city": event.target.city.value,
-        "new_dob": event.target.dob.value
+        "new_dob": event.target.dob.value,
       }
-
-
       // const ok = await modifyService.modifyRequest(modifiedUser)
       props.changeUserSettings(modifiedUser.new_country, modifiedUser.new_city, modifiedUser.new_dob)
-      //console.log(modifiedUser)
       props.notify(props.settings.strings["account_modify_ok"], false, 8)
       props.history.push("/my-account/")
-
     }
-
   }
-  {/*
+  /*
     const modifyConfirmClickSoMe = async (event) => {
     //console.log("attempting profile modification")
     event.preventDefault()
@@ -217,47 +206,60 @@ export const UserSettings = (props) => {
       }
 
 
-      else{ */}
-  return(
-      <div className="userSettingsContainer centerAlignWithPadding">
-        <div className="titleContainer">
-          <h1 className="titleText">{props.settings.strings["account_settings"]}</h1>
-        </div>
-        {/*<div className="deleteAccountButtonContainer">
-              <button className="rippleButton" onClick={toggleDeleteAccount}>{props.settings.strings["delete_account"]}</button>
-        </div> */}
-
-        <form className="userSettingsForm" onSubmit={modifyConfirmClick}>
-
-          <div>
-            <div className="infoTextContainer">
-              <p className="normalText">{props.settings.strings["enter_values_to_change"]}</p>
-            </div>
-
-            <div className="inputContainer">
-              <input name="country" className="input" placeholder={props.user !== null && props.user.country !== "" ? props.settings.strings["country"] + ": " + props.user.country : props.settings.strings["country"]} maxLength="2"/>
-              <div className="inputFocusLine"/>
-            </div>
-
-            <div className="inputContainer">
-              <input name="city" className="input" placeholder={props.user !== null && props.user.city !== "" ? props.settings.strings["city"] + ": " + props.user.city : props.settings.strings["city"]} maxLength="32"/>
-              <div className="inputFocusLine"/>
-            </div>
-
-            <div className="inputContainer">
-              <input type="month" name="dob" className="input" maxLength="32"/>
-              <div className="inputFocusLine"/>
-            </div>
-          </div>
-
-          <div className="dualButtonContainer">
-            <button className="positiveButton rippleButton fillButton">{props.settings.strings["confirm"]}</button>
-            <button className="negativeButton rippleButton fillButton" onClick={() => props.history.push("/my-account/")}>Skip</button>
-          </div>
-
-
-        </form>
+      else{ */
+  return (
+    <div className="userSettingsContainer centerAlignWithPadding">
+      <div className="titleContainer">
+        <h1 className="titleText">{props.settings.strings["account_settings"]}</h1>
       </div>
+      {/*<div className="deleteAccountButtonContainer">
+            <button className="rippleButton" onClick={toggleDeleteAccount}>{props.settings.strings["delete_account"]}</button>
+      </div> */}
+      <form className="userSettingsForm" onSubmit={modifyConfirmClick}>
+        <div>
+          <div className="infoTextContainer">
+            <p className="normalText">{props.settings.strings["enter_values_to_change"]}</p>
+          </div>
+          <div className="inputContainer">
+            <input 
+              name="country"
+              className="input"
+              placeholder={props.user !== null && props.user.country !== ""
+                ? props.settings.strings["country"] + ": " + props.user.country
+                : props.settings.strings["country"]} 
+              maxLength="2"
+            />
+            <div className="inputFocusLine"/>
+          </div>
+          <div className="inputContainer">
+            <input
+              name="city"
+              className="input"
+              placeholder={props.user !== null && props.user.city !== ""
+                ? props.settings.strings["city"] + ": " + props.user.city
+                : props.settings.strings["city"]} 
+              maxLength="32"
+            />
+            <div className="inputFocusLine"/>
+          </div>
+          <div className="inputContainer">
+            <input type="month" name="dob" className="input" maxLength="32"/>
+            <div className="inputFocusLine"/>
+          </div>
+        </div>
+        <div className="dualButtonContainer">
+          <button className="positiveButton rippleButton fillButton">
+            {props.settings.strings["confirm"]}
+          </button>
+          <button
+            className="negativeButton rippleButton fillButton"
+            onClick={() => props.history.push("/my-account/")}
+          >
+            Skip
+          </button>
+        </div>
+      </form>
+    </div>
   )
 }
 //}
@@ -277,6 +279,6 @@ const mapDispatchToProps = {
 }
 
 export default connect(
-    mapStateToProps,
-    mapDispatchToProps
+  mapStateToProps,
+  mapDispatchToProps
 )(UserSettings)

--- a/src/components/UserSettings.js
+++ b/src/components/UserSettings.js
@@ -255,7 +255,7 @@ export const UserSettings = (props) => {
             className="negativeButton rippleButton fillButton"
             onClick={() => props.history.push("/my-account/")}
           >
-            Skip
+            {props.settings.strings["skip"]}
           </button>
         </div>
       </form>

--- a/src/strings/stringStorage.json
+++ b/src/strings/stringStorage.json
@@ -188,7 +188,8 @@
       "birthday": "Date of birth",
       "change_information": "Change information",
       "download_info": "Download information",
-      "country_name": "Country"
+      "country_name": "Country",
+      "skip": "Skip"
     },
     "fi":{
       "look_at_mementos": "Katsele kohteen tietoja",
@@ -374,7 +375,8 @@
       "birthday": "Syntymäaika",
       "change_information": "Muuta tietoja",
       "download_info": "Lataa tiedot",
-      "country_name": "Maa"
+      "country_name": "Maa",
+      "skip": "Ohita"
     }
   }
 }


### PR DESCRIPTION
In addition to checking out the code the reviewer should also test on their local machine at least the following steps:

- Changing project info still works as expected
- Changing the settings updates immediately in the Web UI
- There is no unexpected behaviour